### PR TITLE
Don't promote wallets that abuse the blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Basic requirements:
 - No indication that changes to the code are not properly tested
 - Wallet was publicly announced and released since at least 3 months
 - No concerning bug is found when testing the wallet
+- Does not pollute the blockchain with non-transactional data (such as for sending messages or data storage)
 - Website supports HTTPS and 301 redirects HTTP requests
 - SSL certificate passes [Qualys SSL Labs SSL test](https://www.ssllabs.com/ssltest/)
 - The identity of CEOs and/or developers is public

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -81,31 +81,6 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkpassprivacydisclosurefullnode"
           privacynetwork: "checkpassprivacynetworksupporttorproxy"
-- electrum:
-    title: "Electrum"
-    titleshort: "Electrum"
-    compat: "desktop windows mac linux"
-    level: 2
-    platform:
-      desktop:
-        text: "walletelectrum"
-        link: "https://electrum.org"
-        source: "https://github.com/spesmilo/electrum"
-        screenshot: "electrum.png"
-        os:
-        - windows
-        - mac
-        - linux
-        check:
-          control: "checkgoodcontrolfull"
-          validation: "checkpassvalidationspvservers"
-          transparency: "checkpasstransparencyopensource"
-          environment: "checkfailenvironmentdesktop"
-          privacy: "checkpassprivacybasic"
-        privacycheck:
-          privacyaddressreuse: "checkpassprivacyaddressrotation"
-          privacydisclosure: "checkfailprivacydisclosurecentralized"
-          privacynetwork: "checkpassprivacynetworksupporttorproxy"
 - msigna:
     title: "mSIGNA"
     titleshort: "mSIGNA"


### PR DESCRIPTION
This causes a delisting of Electrum, which is apparently adding a blockchain spam feature in 2.0. Hopefully before the official release, they'll just get rid of that and maybe properly integrate email/IM as they appear to want. Glad to revise this to only modify README in that case.

Ref: https://bitcointalk.org/index.php?topic=915405.msg10060484#msg10060484