### PR TITLE
Limit wallet requirements to security requirements for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The wallet list is based on the personal evaluation of the maintainer(s) and reg
 
 These requirements are meant to be updated and strengthened over time. Innovative wallets are exciting and encouraged, so if your wallet has a good reason for not following some of the rules below, please submit it anyway and we'll consider updating the rules.
 
-Basic requirements:
+Basic security requirements:
 
 - Sufficient users and/or developers feedback can be found without concerning issues, or independent security audit(s) is available
 - No indication that users have been harmed considerably by any issue in relation to the wallet


### PR DESCRIPTION
As suggested on #704 , this pull request limits requirements to security requirements for now.

I think other types of requirements, for instance in this case protecting the network against certain form of abuse of the block chain, could be considered later if:

- There is enough agreement that suggested requirements are indeed considered abuse.
- There is enough indication that such abuses are becoming or will become problematic.
- There is enough indication that adopting these new requirements will be helpful (e.g. if block chain abusing features become popular enough, bitcoin.org would likely end up with a reduced wallet list without having much impact on the issue, making such requirement questionable).