### PR TITLE
Order release history and set latest version using versions number instead of releases date

### DIFF
--- a/_plugins/releases.rb
+++ b/_plugins/releases.rb
@@ -20,6 +20,7 @@ require 'yaml'
 module Jekyll
   
   class ReleasePage < Page
+
     def initialize(site, base, lang, srcdir, src, dstdir, dst, year, month, day)
       @site = site
       @base = base
@@ -29,19 +30,31 @@ module Jekyll
       self.read_yaml(File.join(base, srcdir), src)
       self.data['lang'] = lang
       self.data['date'] = year + '-' + month + '-' + day
+      self.data['version'] = dst.gsub('.md','').gsub(/[a-z]/,'')
+      self.data['versionint'] = versiontoint(self.data['version'])
       self.data['layout'] = 'release'
       if dstdir.index('/releases/') === 0
         self.data['redirect'] = '/en/release/' + dst.gsub('.md','')
         self.data['layout'] = 'redirect'
       else
         self.data['category'] = 'release'
-        if !site.config.has_key?('DOWNLOAD_DATE') or site.config['DOWNLOAD_DATE'] < year + '-' + month + '-' + day
-          site.config['DOWNLOAD_DATE'] = year + '-' + month + '-' + day
-          site.config['DOWNLOAD_VERSION'] = dst.gsub('.md','').gsub(/[a-z]/,'')
+        if !site.config.has_key?('DOWNLOAD_VERSION') or site.config['DOWNLOAD_VERSIONINT'] < self.data['versionint']
+          site.config['DOWNLOAD_VERSIONINT'] = self.data['versionint']
+          site.config['DOWNLOAD_VERSION'] = self.data['version']
         end
         site.pages << ReleasePage.new(site, base, lang, srcdir, src, '/releases/' + year + '/' + month + '/' + day, dst, year, month, day)
       end
     end
+
+    def versiontoint(v)
+      x = 0
+      ar = v.split('.').map{|s| s.to_i}
+      ar.each_index do |k|
+        x += ar[k] * (1000 ** (5 - k))
+      end
+      return x
+    end
+
   end
 
   class ReleasePageGenerator < Generator

--- a/en/version-history.html
+++ b/en/version-history.html
@@ -11,7 +11,7 @@ title: Bitcoin Core version history
 <div class="versiontext">
   <h1>Bitcoin Core version history<a type="application/rss+xml" href="/en/rss/releases.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h1>
   <ul>
-  {% filter_for p in site.pages reversed sort_by:date category:release %}
+  {% filter_for p in site.pages reversed sort_by:versionint category:release %}
     <li>
       {{ p.date | date:"%Y-%m-%d" }} - <a href="{{ p.url | replace:'.html','' }}">{{ p.title }}</a>
     </li>


### PR DESCRIPTION
[This comment](https://github.com/bitcoin/bitcoin.org/pull/710#issuecomment-70415594) outlined that releases numbers might not always be in chronological order (e.g. 0.9.5 to be released after 0.10.0) which would affect the version served on the download page as well as the order on the version history page.

This pull request should prevent this issue as long as version numbers do not use more decimal places or digits than this example "000.000.000.000.000" .

In the absence of critical feedback, this pull request will be merged on January 21th.