### PR TITLE
Dev Docs: Mention Upcoming v3 Blocks/BIP66

### DIFF
--- a/_autocrossref.yaml
+++ b/_autocrossref.yaml
@@ -72,6 +72,7 @@ data-pushing op code:
 data-pushing op codes: data-pushing op code
 denomination:
 denominations: denomination
+DER:
 DER format: der
 DER-formatted: der
 difficulty:
@@ -344,6 +345,7 @@ BIP39:
 BIP50:
 BIP61:
 BIP62:
+BIP66:
 BIP70:
 BIP71:
 BIP72:

--- a/_includes/ref_block_chain.md
+++ b/_includes/ref_block_chain.md
@@ -65,16 +65,24 @@ fe9f0864 ........................... Nonce
   <!-- source for heights: my (@harding) own headers dump and counting
   script -->
 
-* **Version 3** blocks will likely be introduced in the near-future as
+* **Version 3** blocks will be introduced when sufficient numbers of
+  miners switch to using Bitcoin Core 0.10.0 and other versions that
+  create version 3 blocks. As described in draft BIP66, this soft fork
+  change requires strict DER encoding for all ECDSA signatures used in
+  transactions appearing in version 3 or later blocks. Transactions that
+  do not use strict DER encoding have been non-standard since Bitcoin
+  Core 0.8.0.
+
+* **Version 4** blocks will likely be introduced in the near-future as
   specified in draft BIP62. Possible changes include:
 
-    * Reject version 3 blocks that include any version 2 transactions
+    * Reject version 4 blocks that include any version 2 transactions
       that don't adhere to any of the version 2 transaction rules.
       These rules are not yet described in this documentation; see
       BIP62 for details.
 
-    * A soft fork rollout of version 3 blocks identical to the rollout
-      used for version 2 blocks (described briefly in BIP62 and in more
+    * A soft fork rollout of version 4 blocks identical to the rollout
+      used for version 3 blocks (described briefly in BIP62 and in more
       detail in BIP34).
 
 {% endautocrossref %}

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -356,6 +356,7 @@ http://opensource.org/licenses/MIT.
 [BIP50]: https://github.com/bitcoin/bips/blob/master/bip-0050.mediawiki
 [BIP61]: https://github.com/bitcoin/bips/blob/master/bip-0061.mediawiki
 [BIP62]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
+[BIP66]: https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
 [BIP70]: https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki
 [BIP71]: https://github.com/bitcoin/bips/blob/master/bip-0071.mediawiki
 [BIP72]: https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki
@@ -386,7 +387,7 @@ http://opensource.org/licenses/MIT.
 [core paymentrequest.proto]: https://github.com/bitcoin/bitcoin/blob/master/src/qt/paymentrequest.proto
 [core script.h]: https://github.com/bitcoin/bitcoin/blob/master/src/script.h
 [creative commons attribution 3.0 license]: https://creativecommons.org/licenses/by/3.0/
-[DER]: https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One
+[DER]: https://en.wikipedia.org/wiki/X.690#DER_encoding
 [dig command]: https://en.wikipedia.org/wiki/Dig_%28Unix_command%29
 [DNS A records]: http://tools.ietf.org/html/rfc1035#section-3.2.2
 [DNS Seed Policy]: https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md


### PR DESCRIPTION
Preview: http://dg2.dtrt.org/en/developer-reference#block-versions

Briefly mention upcoming v3 blocks and BIP66 (strict DER).  We don't currently have any docs about creating signatures, so I don't think there's anything else we need to change.

Note: the link to BIP66 is broken because Greg Maxwell just assigned the BIP number. I won't merge this request until the link works.