### PR TITLE
Remove "France Bitcoin" from resources page

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -14,7 +14,6 @@ id: resources
     <h2><img src="/img/icons/ico_simple.svg" class="titleicon" alt="Icon">{% translate useful %}</h2>
     <p><a href="https://bitcoinfoundation.org/">Bitcoin Foundation</a></p>
     <p>{% translate linkwiki %}</p>
-    {% if page.lang == 'fr' %}<p><a href="http://francebitcoin.com/">France Bitcoin</a></p>{% endif %}
     <p><a href="https://www.weusecoins.com/">WeUseCoins.com</a></p>
     <p><a href="http://www.bitcoinmining.com/">BitcoinMining.com</a></p>
   </div><div>
@@ -30,6 +29,7 @@ id: resources
     <h2><img src="/img/icons/ico_spread.svg" class="titleicon" alt="Icon">{% translate news %}</h2>
     {% if page.lang == 'fr' %}<p><a href="http://le-coin-coin.fr/">Le Coin Coin</a></p>{% endif %}
     {% if page.lang == 'fr' %}<p><a href="http://www.bitcoin.fr/">Bitcoin.fr</a></p>{% endif %}
+    {% if page.lang == 'fr' %}<p><a href="http://francebitcoin.com/">France Bitcoin</a></p>{% endif %}
     {% if page.lang == 'bg' %}<p><a href="http://hash.bg/">Hash.bg</a></p>{% endif %}
     {% if page.lang == 'ru' %}<p><a href="http://bitnovosti.com/">Bit•Новости</a></p>
     <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}

--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -29,7 +29,6 @@ id: resources
     <h2><img src="/img/icons/ico_spread.svg" class="titleicon" alt="Icon">{% translate news %}</h2>
     {% if page.lang == 'fr' %}<p><a href="http://le-coin-coin.fr/">Le Coin Coin</a></p>{% endif %}
     {% if page.lang == 'fr' %}<p><a href="http://www.bitcoin.fr/">Bitcoin.fr</a></p>{% endif %}
-    {% if page.lang == 'fr' %}<p><a href="http://francebitcoin.com/">France Bitcoin</a></p>{% endif %}
     {% if page.lang == 'bg' %}<p><a href="http://hash.bg/">Hash.bg</a></p>{% endif %}
     {% if page.lang == 'ru' %}<p><a href="http://bitnovosti.com/">Bit•Новости</a></p>
     <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}


### PR DESCRIPTION
"[France Bitcoin](http://francebitcoin.com/)" should be moved from Useful places to the News section, since it's only a news website.
Edit : Maybe it should even be deleted as the last post is almost 1 year old...