### PR TITLE
Small error in the French translation (Bitcoin instead of Bit)

### DIFF
--- a/_translations/fr.yml
+++ b/_translations/fr.yml
@@ -614,7 +614,7 @@ fr:
     address: "Adresse"
     addresstxt: "Une adresse Bitcoin est <b>similaire à une adresse physique ou une adresse courriel</b>. Il s'agit de la seule information que vous avez besoin de fournir pour que quelqu'un vous paie avec Bitcoin. Une différence importante toutefois, est que chaque adresse Bitcoin ne devrait être utilisée que pour une seule transaction."
     bit: "Bit"
-    bittxt: "Bitcoin est une unité courante utilisée pour désigner une sous-unité d'un bitcoin - 1 000 000 bits est égal à 1 bitcoin (BTC or B⃦). Cette unité est souvent plus pratique pour fixer les prix des pourboires, des biens et des services."
+    bittxt: "Bit est une unité courante utilisée pour désigner une sous-unité d'un bitcoin - 1 000 000 bits est égal à 1 bitcoin (BTC or B⃦). Cette unité est souvent plus pratique pour fixer les prix des pourboires, des biens et des services."
     bitcoin: "Bitcoin"
     bitcointxt: "Bitcoin - avec une majuscule, est utilisé pour décrire le concept du Bitcoin ou le réseau lui-même. Ex. \"Je me suis intéressé au protocole Bitcoin aujourd'hui\"<br>bitcoin - sans majuscule, est utilisé pour désigner les bitcoins en tant qu'unité de compte. Ex. \"J'ai envoyé dix bitcoins aujourd'hui\". On le retrouve souvent sous sa forme abrégée BTC ou XBT."
     blockchain: "Chaine de blocs"


### PR DESCRIPTION
There is a small error in the French translation of the [Vocabulary](https://bitcoin.org/fr/vocabulaire#bit) page:
"**Bit** is a common unit" is translated into French as "**Bitcoin** est une unité courante"