### PR TITLE
Wallets: Revert "Drop good tor privacy score for mycelium"

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -480,7 +480,7 @@ wallets:
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurecentralized"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
+          privacynetwork: "checkpassprivacynetworksupporttorproxy"
 - bitgo:
     title: "BitGo"
     titleshort: "BitGo"


### PR DESCRIPTION
This reverts commit bf452cdc171eeddf4015034297bb59c907dd04eb.

According to @apetersson in merged pull #630, Mycelium now supports using Tor, so this restores that part of their score.

In the absence of critical feedback, I'll verify this and merge it in about 72 hours (17:00 UTC Saturday).