### PR TITLE
Reduce future changes to the javascript code of the download page

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,7 +14,8 @@
 <!--[if lt IE 8]>{% lesscss ie.css %}<script type="text/javascript" src="/js/ie.js"></script><![endif]-->
 {% if page.lang == 'ar' or page.lang == 'fa' %}{% lesscss rtl.less %}{% endif %}
 {% if page.lang == 'bg' or page.lang == 'el' or page.lang == 'ko' or page.lang == 'hi' or page.lang == 'pl' or page.lang == 'sl' or page.lang == 'ro' or page.lang == 'ru' or page.lang == 'tr' or page.lang == 'uk' or page.lang == 'zh_CN' or page.lang == 'zh_TW' %}{% lesscss sans.less %}{% endif %}
-<script type="text/javascript" src="/js/main.js"></script>
+<script type="text/javascript" src="/js/base.js"></script>
+{% if page.id != 'download' %}<script type="text/javascript" src="/js/main.js"></script>{% endif %}
 <link rel="shortcut icon" href="/favicon.png">
 <link rel="apple-touch-icon-precomposed" href="/img/icons/logo_ios.png"/>
 </head>

--- a/_templates/download.html
+++ b/_templates/download.html
@@ -30,21 +30,21 @@ lin64: "linux64.tar.gz"
         <img src="/img/os/med_win.png" alt="windows">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64exe }}" id="downloadwinexe">Windows</a>
-          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64exe }}">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32exe }}">32 bit</a></span>
+          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64exe }}" id="win64exe">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32exe }}" id="win32exe">32 bit</a></span>
         </span>
       </div>
       <div>
         <img src="/img/os/med_win.png" alt="windows">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64zip }}" id="downloadwinzip">Windows (zip)</a>
-          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64zip }}">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32zip }}">32 bit</a></span>
+          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64zip }}" id="win64zip">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32zip }}" id="win32zip">32 bit</a></span>
         </span>
       </div>
       <div>
         <img src="/img/os/med_osx.png" alt="osx">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ page.macdmg }}">Mac OS X</a>
-          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ page.macdmg }}">dmg</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.mactar }}">tar.gz</a></span>
+          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ page.macdmg }}" id="macdmg">dmg</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.mactar }}" id="mactar">tar.gz</a></span>
         </span>
       </div>
     </div>
@@ -53,7 +53,7 @@ lin64: "linux64.tar.gz"
         <img src="/img/os/med_linux.png" alt="linux">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin64 }}" id="downloadlin">Linux (tgz)</a>
-          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin64 }}">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin32 }}">32 bit</a></span>
+          <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin64 }}" id="lin64">64 bit</a> - <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin32 }}" id="lin32">32 bit</a></span>
         </span>
       </div>
       <div>
@@ -93,28 +93,36 @@ var but = document.getElementById('downloadbutton');
 var linkwinexe = document.getElementById('downloadwinexe');
 var linkwinzip = document.getElementById('downloadwinzip');
 var linklin = document.getElementById('downloadlin');
+var hrefwin64exe = document.getElementById('win64exe').href;
+var hrefwin32exe = document.getElementById('win32exe').href;
+var hrefwin64zip = document.getElementById('win64zip').href;
+var hrefwin32zip = document.getElementById('win32zip').href;
+var hrefmacdmg = document.getElementById('macdmg').href;
+var hrefmactar = document.getElementById('mactar').href;
+var hreflin64 = document.getElementById('lin64').href;
+var hreflin32 = document.getElementById('lin32').href;
 switch (os) {
 case 'windows64':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_windows.svg';
-	but.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64exe }}';
-	linkwinexe.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64exe }}';
-	linkwinzip.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win64zip }}';
+	but.href = hrefwin64exe;
+	linkwinexe.href = hrefwin64exe;
+	linkwinzip.href = hrefwin64zip;
 break;
 case 'windows32':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_windows.svg';
-	but.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32exe }}';
-	linkwinexe.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32exe }}';
-	linkwinzip.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.win32zip }}';
+	but.href = hrefwin32exe;
+	linkwinexe.href = hrefwin32exe;
+	linkwinzip.href = hrefwin32zip;
 break;
 case 'linux64':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_linux.png';
-	but.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin64 }}';
-	linklin.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin64 }}';
+	but.href = hreflin64;
+	linklin.href = hreflin64;
 break;
 case 'linux32':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_linux.png';
-	but.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin32 }}';
-	linklin.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ page.lin32 }}';
+	but.href = hreflin32;
+	linklin.href = hreflin32;
 break;
 case 'ubuntu':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_ubuntu.svg';
@@ -122,7 +130,7 @@ case 'ubuntu':
 break;
 case 'mac':
 	but.getElementsByTagName('IMG')[0].src = '/img/os/but_mac.svg';
-	but.href = '{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ page.macdmg }}';
+	but.href = hrefmacdmg;
 break;
 }
 </script>

--- a/js/base.js
+++ b/js/base.js
@@ -1,0 +1,113 @@
+// This file is licensed under the MIT License (MIT) available on
+// http://opensource.org/licenses/MIT.
+
+// This file should be used only for javascript code
+// necessary for all pages to work properly.
+
+function addEvent(a, b, c) {
+// Attach event to a DOM node.
+// Ex. addEvent(node,'click',function);
+return (a.addEventListener) ? a.addEventListener(b, c, false) : (a.attachEvent) ? a.attachEvent('on' + b, c) : false;
+}
+
+function removeEvent(a, b, c) {
+// Detach event from a DOM node.
+// Ex. removeEvent(node,'click',function);
+return (a.removeEventListener) ? a.removeEventListener(b, c, false) : (a.detachEvent) ? a.detachEvent('on' + b, c) : false;
+}
+
+function cancelEvent(e) {
+// Cancel current event.
+// Ex. cancelEvent(event);
+if (!e) var e = window.event;
+(e.preventDefault) ? e.preventDefault() : e.returnValue = false;
+}
+
+function getEventTarget(e) {
+// Return target DOM node on which the event is triggered.
+// Ex. getEventTarget(event);
+if (!e) var e = window.event;
+return (e.target && e.target.nodeType == 3) ? e.target.parentNode : (e.target) ? e.target : e.srcElement;
+}
+
+function getStyle(a, b) {
+// Return the value of the computed style on a DOM node.
+// Ex. getStyle(node,'padding-bottom');
+if (window.getComputedStyle) return document.defaultView.getComputedStyle(a, null).getPropertyValue(b);
+var n = b.indexOf('-');
+if (n !== -1) b = b.substr(0, n) + b.substr(n + 1, 1).toUpperCase() + b.substr(n + 2);
+return a.currentStyle[b];
+}
+
+function addClass(node, data) {
+// Add class to node.
+var cl = node.className.split(' ');
+for (var i = 0, n = cl.length; i < n; i++) {
+	if (cl[i] == data) return;
+}
+cl.push(data);
+node.className = cl.join(' ');
+}
+
+function removeClass(node, data) {
+// Remove class from node.
+var ocl = node.className.split(' ');
+var ncl = [];
+for (var i = 0, n = ocl.length; i < n; i++) {
+	if (ocl[i] != data) ncl.push(ocl[i]);
+}
+node.className = ncl.join(' ');
+}
+
+function supportsSVG() {
+// Return true if the browser supports SVG.
+// Ex. if(!supportsSVG()){..apply png fallback..}
+// Old FF 3.5 and Safari 3 versions have svg support, but a very poor one
+// http://www.w3.org/TR/SVG11/feature#Image Defeat FF 3.5 only
+// http://www.w3.org/TR/SVG11/feature#Animation Defeat Saf 3 but also returns false in IE9
+// http://www.w3.org/TR/SVG11/feature#BasicGraphicsAttribute Defeat Saf 3 but also returns false in Chrome and safari4
+// http://www.w3.org/TR/SVG11/feature#Text Defeat Saf 3 but also returns false in FF and safari4
+if (!document.createElementNS || !document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect) return false;
+if (!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1")) return false;
+if (!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicGraphicsAttribute", "1.1") && !document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Animation", "1.1") && !document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Text", "1.1")) return false;
+return true;
+}
+
+function fallbackSVG() {
+// Replace all images extensions from .svg to .png if browser doesn't support SVG files.
+if (supportsSVG()) return;
+for (var i = 0, nd = document.getElementsByTagName('*'), n = nd.length; i < n; i++) {
+	if (nd[i].nodeName == 'IMG' && /.*\.svg$/.test(nd[i].src)) nd[i].src = nd[i].src.slice(0, -3) + 'png';
+	if (/\.svg/.test(getStyle(nd[i], 'background-image'))) nd[i].style.backgroundImage = getStyle(nd[i], 'background-image').replace('.svg', '.png');
+	if (/\.svg/.test(getStyle(nd[i], 'background'))) nd[i].style.background = getStyle(nd[i], 'background').replace('.svg', '.png');
+}
+}
+
+function mobileMenuShow(e) {
+// Show the mobile menu when the visitors touch the menu icon.
+var mm = document.getElementById('menusimple');
+var ml = document.getElementById('langselect');
+var t = document.getElementById('menumobile');
+mm.style.display = ml.style.display = (mm.style.display == 'block') ? '' : 'block';
+t.parentNode.removeChild(t);
+cancelEvent(e);
+}
+
+function mobileMenuHover(e) {
+// Add a delay before hiding menu for mobiles to prevent accidental clicks.
+var p = t = getEventTarget(e);
+if (t.nodeName != 'A') return;
+while (p.parentNode.nodeName != 'DIV') p = p.parentNode;
+while (t.nodeName != 'LI' || t.parentNode != p) t = t.parentNode;
+var ul = null;
+if (t.getElementsByTagName('UL').length > 0) {
+	var ul = t.getElementsByTagName('UL')[0];
+	addClass(ul, 'hover');
+}
+setTimeout(function() {
+	for (var i = 0, nd = p.getElementsByTagName('UL'), n = nd.length; i < n; i++) {
+		if (nd[i] == ul) continue;
+		removeClass(nd[i], 'hover');
+	}
+}, 1);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,40 +1,8 @@
 // This file is licensed under the MIT License (MIT) available on
 // http://opensource.org/licenses/MIT.
 
-function addEvent(a, b, c) {
-// Attach event to a DOM node.
-// Ex. addEvent(node,'click',function);
-return (a.addEventListener) ? a.addEventListener(b, c, false) : (a.attachEvent) ? a.attachEvent('on' + b, c) : false;
-}
-
-function removeEvent(a, b, c) {
-// Detach event from a DOM node.
-// Ex. removeEvent(node,'click',function);
-return (a.removeEventListener) ? a.removeEventListener(b, c, false) : (a.detachEvent) ? a.detachEvent('on' + b, c) : false;
-}
-
-function cancelEvent(e) {
-// Cancel current event.
-// Ex. cancelEvent(event);
-if (!e) var e = window.event;
-(e.preventDefault) ? e.preventDefault() : e.returnValue = false;
-}
-
-function getEventTarget(e) {
-// Return target DOM node on which the event is triggered.
-// Ex. getEventTarget(event);
-if (!e) var e = window.event;
-return (e.target && e.target.nodeType == 3) ? e.target.parentNode : (e.target) ? e.target : e.srcElement;
-}
-
-function getStyle(a, b) {
-// Return the value of the computed style on a DOM node.
-// Ex. getStyle(node,'padding-bottom');
-if (window.getComputedStyle) return document.defaultView.getComputedStyle(a, null).getPropertyValue(b);
-var n = b.indexOf('-');
-if (n !== -1) b = b.substr(0, n) + b.substr(n + 1, 1).toUpperCase() + b.substr(n + 2);
-return a.currentStyle[b];
-}
+// This file is used for javascript code
+// necessary for some pages to work properly.
 
 function getWidth(a) {
 // Return the integer value of the computed width of a DOM node.
@@ -71,7 +39,7 @@ while (a.offsetParent) {
 return b;
 }
 
-function getTop(a) {
+function getTop (a) {
 // Return the integer value of the computed distance between given node and the browser window.
 // Ex. getTop(node);
 var b = a.offsetTop;
@@ -106,26 +74,6 @@ function isMobile() {
 // Return true if the mobile CSS stylesheet is used.
 if (getStyle(document.getElementById('detectmobile'), 'display') != 'none') return true;
 return false;
-}
-
-function addClass(node, data) {
-// Add class to node.
-var cl = node.className.split(' ');
-for (var i = 0, n = cl.length; i < n; i++) {
-	if (cl[i] == data) return;
-}
-cl.push(data);
-node.className = cl.join(' ');
-}
-
-function removeClass(node, data) {
-// Remove class from node.
-var ocl = node.className.split(' ');
-var ncl = [];
-for (var i = 0, n = ocl.length; i < n; i++) {
-	if (ocl[i] != data) ncl.push(ocl[i]);
-}
-node.className = ncl.join(' ');
 }
 
 function scrollToNode(t) {
@@ -165,59 +113,6 @@ for (var i = 0, n = domPrefixes.length; i < n; i++) {
 	if (nd.style[domPrefixes[i] + idc] !== undefined) return true;
 }
 return false;
-}
-
-function supportsSVG() {
-// Return true if the browser supports SVG.
-// Ex. if(!supportsSVG()){..apply png fallback..}
-// Old FF 3.5 and Safari 3 versions have svg support, but a very poor one
-// http://www.w3.org/TR/SVG11/feature#Image Defeat FF 3.5 only
-// http://www.w3.org/TR/SVG11/feature#Animation Defeat Saf 3 but also returns false in IE9
-// http://www.w3.org/TR/SVG11/feature#BasicGraphicsAttribute Defeat Saf 3 but also returns false in Chrome and safari4
-// http://www.w3.org/TR/SVG11/feature#Text Defeat Saf 3 but also returns false in FF and safari4
-if (!document.createElementNS || !document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect) return false;
-if (!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1")) return false;
-if (!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicGraphicsAttribute", "1.1") && !document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Animation", "1.1") && !document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Text", "1.1")) return false;
-return true;
-}
-
-function fallbackSVG() {
-// Replace all images extensions from .svg to .png if browser doesn't support SVG files.
-if (supportsSVG()) return;
-for (var i = 0, nd = document.getElementsByTagName('*'), n = nd.length; i < n; i++) {
-	if (nd[i].nodeName == 'IMG' && /.*\.svg$/.test(nd[i].src)) nd[i].src = nd[i].src.slice(0, -3) + 'png';
-	if (/\.svg/.test(getStyle(nd[i], 'background-image'))) nd[i].style.backgroundImage = getStyle(nd[i], 'background-image').replace('.svg', '.png');
-	if (/\.svg/.test(getStyle(nd[i], 'background'))) nd[i].style.background = getStyle(nd[i], 'background').replace('.svg', '.png');
-}
-}
-
-function mobileMenuShow(e) {
-// Show the mobile menu when the visitors touch the menu icon.
-var mm = document.getElementById('menusimple');
-var ml = document.getElementById('langselect');
-var t = document.getElementById('menumobile');
-mm.style.display = ml.style.display = (mm.style.display == 'block') ? '' : 'block';
-t.parentNode.removeChild(t);
-cancelEvent(e);
-}
-
-function mobileMenuHover(e) {
-// Add a delay before hiding menu for mobiles to prevent accidental clicks.
-var p = t = getEventTarget(e);
-if (t.nodeName != 'A') return;
-while (p.parentNode.nodeName != 'DIV') p = p.parentNode;
-while (t.nodeName != 'LI' || t.parentNode != p) t = t.parentNode;
-var ul = null;
-if (t.getElementsByTagName('UL').length > 0) {
-	var ul = t.getElementsByTagName('UL')[0];
-	addClass(ul, 'hover');
-}
-setTimeout(function() {
-	for (var i = 0, nd = p.getElementsByTagName('UL'), n = nd.length; i < n; i++) {
-		if (nd[i] == ul) continue;
-		removeClass(nd[i], 'hover');
-	}
-}, 1);
 }
 
 function boxShow(e) {


### PR DESCRIPTION
I have been working with the help of @harding on allowing the binaries and download page to be closely monitored by scripts. One remaining issue I had was the number of alerts triggered by unimportant changes in the javascript code. This pull request aims to reduce this useless noise by two means.

By only loading the few necessary javascript functions required for this page to work.
By not changing the javascript code on the page on each release.

I'll be happy to wait and rebase this pull request if needed given that the download page is receiving a lot of changes recently.

Edit:

Live preview: http://bitcointest1.us.to/en/download
Result diff: http://bitcointest1.us.to/diff.html