### PR TITLE
Dev Docs: Add Inline Template Plugin And Use It For RPC/REST

### DIFF
--- a/_includes/helpers/vars.md
+++ b/_includes/helpers/vars.md
@@ -3,16 +3,19 @@ This file is licensed under the MIT License (MIT) available on
 http://opensource.org/licenses/MIT.
 {% endcomment %}
 
-{% capture INCLUDE_F_LIST_TRANSACTIONS %}| {{DEPTH}}<br>`involvesWatchonly` | bool           | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the payment involves a watch-only address.  Otherwise not returned
+{% capture INCLUDE_F_LIST_TRANSACTIONS %}
+| {{DEPTH}}<br>`involvesWatchonly` | bool           | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the payment involves a watch-only address.  Otherwise not returned
 | {{DEPTH}}<br>`account`        | string            | Required<br>(exactly 1)     | The account which the payment was credited to or debited from.  May be an empty string ("") for the default account
 | {{DEPTH}}<br>`address`        | string (base58)   | Optional<br>(0 or 1)        | The address paid in this payment, which may be someone else's address not belonging to this wallet.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script
 | {{DEPTH}}<br>`category`       | string            | Required<br>(exactly 1)     | Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain
 | {{DEPTH}}<br>`amount`         | number (bitcoins) | Required<br>(exactly 1)     | A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)
 | {{DEPTH}}<br>`vout`           | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index
-| {{DEPTH}}<br>`fee`            | number (bitcoins) | Optional<br>(0 or 1)        | If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment{% endcapture %}
+| {{DEPTH}}<br>`fee`            | number (bitcoins) | Optional<br>(0 or 1)        | If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment
+{% endcapture %}
 
 
-{% capture INCLUDE_F_LIST_TRANSACTIONS_F_FULL %}| {{DEPTH}}<br>`confirmations`   | number (int)    | Required<br>(exactly 1)     | The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted
+{% capture INCLUDE_F_LIST_TRANSACTIONS_F_FULL %}
+| {{DEPTH}}<br>`confirmations`   | number (int)    | Required<br>(exactly 1)     | The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted
 | {{DEPTH}}<br>`generated`       | bool            | Optional<br>(0 or 1)        | Set to `true` if the transaction is a coinbase.  Not returned for regular transactions
 | {{DEPTH}}<br>`blockhash`       | string (hex)    | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The hash of the block on the local best block chain which includes this transaction, encoded as hex in RPC byte order
 | {{DEPTH}}<br>`blockindex`      | number (int)    | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The block height of the block on the local best block chain which includes this transaction
@@ -23,9 +26,11 @@ http://opensource.org/licenses/MIT.
 | {{DEPTH}}<br>`time`            | number (int)    | Required<br>(exactly 1)     | A Unix epoch time when the transaction was added to the wallet
 | {{DEPTH}}<br>`timerecived`     | number (int)    | Required<br>(exactly 1)     | A Unix epoch time when the transaction was detected by the local node, or the time of the block on the local best block chain that included the transaction
 | {{DEPTH}}<br>`comment`         | string          | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction.  Only returned if a comment was added
-| {{DEPTH}}<br>`to`              | string          | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added{% endcapture %}
+| {{DEPTH}}<br>`to`              | string          | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added
+{% endcapture %}
 
-{% capture INCLUDE_SPEND_CONFIRMATIONS %}| Name               | Type            | Presence                    | Description
+{% capture INCLUDE_SPEND_CONFIRMATIONS %}
+| Name               | Type            | Presence                    | Description
 |--------------------|-----------------|-----------------------------|---------------
 | Confirmations      | number (int)    | Optional<br>(0 or 1)        | The minimum number of confirmations an incoming transaction must have for its outputs to be credited to this account's balance. Outgoing transactions are always counted, as are move transactions made with the `move` RPC. If an account doesn't have a balance high enough to pay for this transaction, the payment will be rejected.  Use `0` to spend unconfirmed incoming payments. Default is `1`
 {:.ntpd}
@@ -36,7 +41,8 @@ it to account2 with the `move` RPC, account2 will be able to spend those
 bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 
 
-{% capture INCLUDE_DECODE_RAW_TRANSACTION %}|{{DEPTH}} →<br>`txid`           | string (hex)    | Required<br>(exactly 1)     | The transaction's TXID encoded as hex in RPC byte order
+{% capture INCLUDE_DECODE_RAW_TRANSACTION %}
+|{{DEPTH}} →<br>`txid`           | string (hex)    | Required<br>(exactly 1)     | The transaction's TXID encoded as hex in RPC byte order
 |{{DEPTH}} →<br>`version`          | number (int)      | Required<br>(exactly 1)     | The transaction format version number
 |{{DEPTH}} →<br>`locktime`         | number (int)      | Required<br>(exactly 1)     | The transaction's locktime: either a Unix epoch date or block height; see the [Locktime parsing rules][]
 |{{DEPTH}} →<br>`vin`              | array             | Required<br>(exactly 1)     | An array of objects with each object being an input vector (vin) for this transaction.  Input objects will have the same order within the array as they have in the transaction, so the first input listed will be input 0
@@ -58,19 +64,24 @@ bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 |{{DEPTH}} → → → →<br>`reqSigs`    | number (int)      | Optional<br>(0 or 1)        | The number of signatures required; this is always `1` for P2PK, P2PKH, and P2SH (including P2SH multisig because the redeem script is not available in the pubkey script).  It may be greater than 1 for bare multisig.  This value will not be returned for `nulldata` or `nonstandard` script types (see the `type` key below)
 |{{DEPTH}} → → → →<br>`type`       | string            | Optional<br>(0 or 1)        | The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script<br>• `pubkeyhash` for a P2PKH script<br>• `scripthash` for a P2SH script<br>• `multisig` for a bare multisig script<br>• `nulldata` for nulldata scripts<br>• `nonstandard` for unknown scripts
 |{{DEPTH}} → → → →<br>`addresses`  | string : array    | Optional<br>(0 or 1)        | The P2PKH or P2SH addresses used in this transaction, or the computed P2PKH address of any pubkeys in this transaction.  This array will not be returned for `nulldata` or `nonstandard` script types
-|{{DEPTH}} → → → → →<br>Address     | string           | Required<br>(1 or more)     | A P2PKH or P2SH address{% endcapture %}
+|{{DEPTH}} → → → → →<br>Address     | string           | Required<br>(1 or more)     | A P2PKH or P2SH address
+{% endcapture %}
 
 {% assign INCLUDE_WALLET_UNLOCKED="If the wallet has been encrypted either through the GUI or with the `encryptwallet` RPC, it must first be unlocked with the `walletpassphrase` RPC" %}
 
-{% capture INCLUDE_CONFIRMATIONS_PARAMETER %}| Name               | Type            | Presence                    | Description
+{% capture INCLUDE_CONFIRMATIONS_PARAMETER %}
+| Name               | Type            | Presence                    | Description
 |--------------------|-----------------|-----------------------------|----------------
 | Confirmations      | number (int)    | Optional<br>(0 or 1)        | The minimum number of confirmations an externally-generated transaction must have before it is counted towards the balance.  Transactions generated by this node are counted immediately.  Typically, externally-generated transactions are payments to this wallet and transactions generated by this node are payments to other wallets.  Use `0` to count unconfirmed transactions.  Default is `1`
-{:.ntpd}{% endcapture %}
+{:.ntpd}
+{% endcapture %}
 
-{% capture INCLUDE_INCLUDE_WATCH_ONLY_PARAMETER %}| Name               | Type            | Presence                    | Description
+{% capture INCLUDE_INCLUDE_WATCH_ONLY_PARAMETER %}
+| Name               | Type            | Presence                    | Description
 |--------------------|-----------------|-----------------------------|----------------
 | Include Watch-Only | bool            | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>If set to `true`, include watch-only addresses in details and calculations as if they were regular addresses belonging to the wallet.  If set to `false` (the default), treat watch-only addresses as if they didn't belong to this wallet
-{:.ntpd}{% endcapture %}
+{:.ntpd}
+{% endcapture %}
 
 {% assign WARNING="![Warning icon](/img/icons/icon_warning.svg) **Warning:**" %}
 

--- a/_includes/helpers/vars.md
+++ b/_includes/helpers/vars.md
@@ -4,36 +4,115 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 {% capture INCLUDE_F_LIST_TRANSACTIONS %}
-| {{DEPTH}}<br>`involvesWatchonly` | bool           | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the payment involves a watch-only address.  Otherwise not returned
-| {{DEPTH}}<br>`account`        | string            | Required<br>(exactly 1)     | The account which the payment was credited to or debited from.  May be an empty string ("") for the default account
-| {{DEPTH}}<br>`address`        | string (base58)   | Optional<br>(0 or 1)        | The address paid in this payment, which may be someone else's address not belonging to this wallet.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script
-| {{DEPTH}}<br>`category`       | string            | Required<br>(exactly 1)     | Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain
-| {{DEPTH}}<br>`amount`         | number (bitcoins) | Required<br>(exactly 1)     | A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)
-| {{DEPTH}}<br>`vout`           | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index
-| {{DEPTH}}<br>`fee`            | number (bitcoins) | Optional<br>(0 or 1)        | If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment
+- n: "{{DEPTH}}<br>`involvesWatchonly`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the payment involves a watch-only address.  Otherwise not returned"
+
+- n: "{{DEPTH}}<br>`account`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The account which the payment was credited to or debited from.  May be an empty string (\"\") for the default account"
+
+- n: "{{DEPTH}}<br>`address`"
+  t: "string (base58)"
+  p: "Optional<br>(0 or 1)"
+  d: "The address paid in this payment, which may be someone else's address not belonging to this wallet.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script"
+
+- n: "{{DEPTH}}<br>`category`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain"
+
+- n: "{{DEPTH}}<br>`amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)"
+
+- n: "{{DEPTH}}<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index"
+
+- n: "{{DEPTH}}<br>`fee`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment"
+
 {% endcapture %}
 
 
 {% capture INCLUDE_F_LIST_TRANSACTIONS_F_FULL %}
-| {{DEPTH}}<br>`confirmations`   | number (int)    | Required<br>(exactly 1)     | The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted
-| {{DEPTH}}<br>`generated`       | bool            | Optional<br>(0 or 1)        | Set to `true` if the transaction is a coinbase.  Not returned for regular transactions
-| {{DEPTH}}<br>`blockhash`       | string (hex)    | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The hash of the block on the local best block chain which includes this transaction, encoded as hex in RPC byte order
-| {{DEPTH}}<br>`blockindex`      | number (int)    | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The block height of the block on the local best block chain which includes this transaction
-| {{DEPTH}}<br>`blocktime`       | number (int)    | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The block header time (Unix epoch time) of the block on the local best block chain which includes this transaction
-| {{DEPTH}}<br>`txid`            | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction, encoded as hex in RPC byte order
-| {{DEPTH}}<br>`walletconflicts` | array           | Required<br>(exactly 1)     | An array containing the TXIDs of other transactions that spend the same inputs (UTXOs) as this transaction.  Array may be empty
-| {{DEPTH}}→<br>TXID             | string (hex)    | Optional<br>(0 or more)     | The TXID of a conflicting transaction, encoded as hex in RPC byte order
-| {{DEPTH}}<br>`time`            | number (int)    | Required<br>(exactly 1)     | A Unix epoch time when the transaction was added to the wallet
-| {{DEPTH}}<br>`timerecived`     | number (int)    | Required<br>(exactly 1)     | A Unix epoch time when the transaction was detected by the local node, or the time of the block on the local best block chain that included the transaction
-| {{DEPTH}}<br>`comment`         | string          | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction.  Only returned if a comment was added
-| {{DEPTH}}<br>`to`              | string          | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added
+- n: "{{DEPTH}}<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted"
+
+- n: "{{DEPTH}}<br>`generated`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if the transaction is a coinbase.  Not returned for regular transactions"
+
+- n: "{{DEPTH}}<br>`blockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The hash of the block on the local best block chain which includes this transaction, encoded as hex in RPC byte order"
+
+- n: "{{DEPTH}}<br>`blockindex`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The block height of the block on the local best block chain which includes this transaction"
+
+- n: "{{DEPTH}}<br>`blocktime`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The block header time (Unix epoch time) of the block on the local best block chain which includes this transaction"
+
+- n: "{{DEPTH}}<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction, encoded as hex in RPC byte order"
+
+- n: "{{DEPTH}}<br>`walletconflicts`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing the TXIDs of other transactions that spend the same inputs (UTXOs) as this transaction.  Array may be empty"
+
+- n: "{{DEPTH}}→<br>TXID"
+  t: "string (hex)"
+  p: "Optional<br>(0 or more)"
+  d: "The TXID of a conflicting transaction, encoded as hex in RPC byte order"
+
+- n: "{{DEPTH}}<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "A Unix epoch time when the transaction was added to the wallet"
+
+- n: "{{DEPTH}}<br>`timerecived`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "A Unix epoch time when the transaction was detected by the local node, or the time of the block on the local best block chain that included the transaction"
+
+- n: "{{DEPTH}}<br>`comment`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "For transaction originating with this wallet, a locally-stored comment added to the transaction.  Only returned if a comment was added"
+
+- n: "{{DEPTH}}<br>`to`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added"
+
 {% endcapture %}
 
 {% capture INCLUDE_SPEND_CONFIRMATIONS %}
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Confirmations      | number (int)    | Optional<br>(0 or 1)        | The minimum number of confirmations an incoming transaction must have for its outputs to be credited to this account's balance. Outgoing transactions are always counted, as are move transactions made with the `move` RPC. If an account doesn't have a balance high enough to pay for this transaction, the payment will be rejected.  Use `0` to spend unconfirmed incoming payments. Default is `1`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Confirmations"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The minimum number of confirmations an incoming transaction must have for its outputs to be credited to this account's balance. Outgoing transactions are always counted, as are move transactions made with the `move` RPC. If an account doesn't have a balance high enough to pay for this transaction, the payment will be rejected.  Use `0` to spend unconfirmed incoming payments. Default is `1`"
+
+{% enditemplate %}
 
 ![Warning icon](/img/icons/icon_warning.svg)
 **Warning:** if account1 receives an unconfirmed payment and transfers
@@ -42,45 +121,143 @@ bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 
 
 {% capture INCLUDE_DECODE_RAW_TRANSACTION %}
-|{{DEPTH}} →<br>`txid`           | string (hex)    | Required<br>(exactly 1)     | The transaction's TXID encoded as hex in RPC byte order
-|{{DEPTH}} →<br>`version`          | number (int)      | Required<br>(exactly 1)     | The transaction format version number
-|{{DEPTH}} →<br>`locktime`         | number (int)      | Required<br>(exactly 1)     | The transaction's locktime: either a Unix epoch date or block height; see the [Locktime parsing rules][]
-|{{DEPTH}} →<br>`vin`              | array             | Required<br>(exactly 1)     | An array of objects with each object being an input vector (vin) for this transaction.  Input objects will have the same order within the array as they have in the transaction, so the first input listed will be input 0
-|{{DEPTH}} → →<br>Input            | object            | Required<br>(1 or more)     | An object describing one of this transaction's inputs.  May be a regular input or a coinbase
-|{{DEPTH}} → → →<br>`txid`         | string            | Optional<br>(0 or 1)        | The TXID of the outpoint being spent, encoded as hex in RPC byte order.  Not present if this is a coinbase transaction
-|{{DEPTH}} → → →<br>`vout`         | number (int)      | Optional<br>(0 or 1)        | The output index number (vout) of the outpoint being spent.  The first output in a transaction has an index of `0`.  Not present if this is a coinbase transaction
-|{{DEPTH}} → → →<br>`scriptSig`    | object            | Optional<br>(0 or 1)        | An object describing the signature script of this input.  Not present if this is a coinbase transaction
-|{{DEPTH}} → → → →<br>`asm`        | string            | Required<br>(exactly 1)     | The signature script in decoded form with non-data-pushing op codes listed
-|{{DEPTH}} → → → →<br>`hex`        | string (hex)      | Required<br>(exactly 1)     | The signature script encoded as hex
-|{{DEPTH}} → → →<br>`coinbase`     | string (hex)      | Optional<br>(0 or 1)        | The coinbase (similar to the hex field of a scriptSig) encoded as hex.  Only present if this is a coinbase transaction
-|{{DEPTH}} → → →<br>`sequence`     | number (int)      | Required<br>(exactly 1)     | The input sequence number
-|{{DEPTH}} →<br>`vout`             | array             | Required<br>(exactly 1)     | An array of objects each describing an output vector (vout) for this transaction.  Output objects will have the same order within the array as they have in the transaction, so the first output listed will be output 0
-|{{DEPTH}} → →<br>Output           | object            | Required<br>(1 or more)     | An object describing one of this transaction's outputs
-|{{DEPTH}} → → →<br>`value`        | number (bitcoins) | Required<br>(exactly 1)     | The number of bitcoins paid to this output.  May be `0`
-|{{DEPTH}} → → →<br>`n`            | number (int)      | Required<br>(exactly 1)     | The output index number of this output within this transaction
-|{{DEPTH}} → → →<br>`scriptPubKey` | object            | Required<br>(exactly 1)     | An object describing the pubkey script
-|{{DEPTH}} → → → →<br>`asm`        | string            | Required<br>(exactly 1)     | The pubkey script in decoded form with non-data-pushing op codes listed
-|{{DEPTH}} → → → →<br>`hex`        | string (hex)      | Required<br>(exactly 1)     | The pubkey script encoded as hex
-|{{DEPTH}} → → → →<br>`reqSigs`    | number (int)      | Optional<br>(0 or 1)        | The number of signatures required; this is always `1` for P2PK, P2PKH, and P2SH (including P2SH multisig because the redeem script is not available in the pubkey script).  It may be greater than 1 for bare multisig.  This value will not be returned for `nulldata` or `nonstandard` script types (see the `type` key below)
-|{{DEPTH}} → → → →<br>`type`       | string            | Optional<br>(0 or 1)        | The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script<br>• `pubkeyhash` for a P2PKH script<br>• `scripthash` for a P2SH script<br>• `multisig` for a bare multisig script<br>• `nulldata` for nulldata scripts<br>• `nonstandard` for unknown scripts
-|{{DEPTH}} → → → →<br>`addresses`  | string : array    | Optional<br>(0 or 1)        | The P2PKH or P2SH addresses used in this transaction, or the computed P2PKH address of any pubkeys in this transaction.  This array will not be returned for `nulldata` or `nonstandard` script types
-|{{DEPTH}} → → → → →<br>Address     | string           | Required<br>(1 or more)     | A P2PKH or P2SH address
+- n: "{{DEPTH}} →<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction's TXID encoded as hex in RPC byte order"
+
+- n: "{{DEPTH}} →<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction format version number"
+
+- n: "{{DEPTH}} →<br>`locktime`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction's locktime: either a Unix epoch date or block height; see the [Locktime parsing rules][]"
+
+- n: "{{DEPTH}} →<br>`vin`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects with each object being an input vector (vin) for this transaction.  Input objects will have the same order within the array as they have in the transaction, so the first input listed will be input 0"
+
+- n: "{{DEPTH}} → →<br>Input"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing one of this transaction's inputs.  May be a regular input or a coinbase"
+
+- n: "{{DEPTH}} → → →<br>`txid`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The TXID of the outpoint being spent, encoded as hex in RPC byte order.  Not present if this is a coinbase transaction"
+
+- n: "{{DEPTH}} → → →<br>`vout`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The output index number (vout) of the outpoint being spent.  The first output in a transaction has an index of `0`.  Not present if this is a coinbase transaction"
+
+- n: "{{DEPTH}} → → →<br>`scriptSig`"
+  t: "object"
+  p: "Optional<br>(0 or 1)"
+  d: "An object describing the signature script of this input.  Not present if this is a coinbase transaction"
+
+- n: "{{DEPTH}} → → → →<br>`asm`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The signature script in decoded form with non-data-pushing op codes listed"
+
+- n: "{{DEPTH}} → → → →<br>`hex`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The signature script encoded as hex"
+
+- n: "{{DEPTH}} → → →<br>`coinbase`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The coinbase (similar to the hex field of a scriptSig) encoded as hex.  Only present if this is a coinbase transaction"
+
+- n: "{{DEPTH}} → → →<br>`sequence`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The input sequence number"
+
+- n: "{{DEPTH}} →<br>`vout`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects each describing an output vector (vout) for this transaction.  Output objects will have the same order within the array as they have in the transaction, so the first output listed will be output 0"
+
+- n: "{{DEPTH}} → →<br>Output"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing one of this transaction's outputs"
+
+- n: "{{DEPTH}} → → →<br>`value`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of bitcoins paid to this output.  May be `0`"
+
+- n: "{{DEPTH}} → → →<br>`n`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number of this output within this transaction"
+
+- n: "{{DEPTH}} → → →<br>`scriptPubKey`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the pubkey script"
+
+- n: "{{DEPTH}} → → → →<br>`asm`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The pubkey script in decoded form with non-data-pushing op codes listed"
+
+- n: "{{DEPTH}} → → → →<br>`hex`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The pubkey script encoded as hex"
+
+- n: "{{DEPTH}} → → → →<br>`reqSigs`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of signatures required; this is always `1` for P2PK, P2PKH, and P2SH (including P2SH multisig because the redeem script is not available in the pubkey script).  It may be greater than 1 for bare multisig.  This value will not be returned for `nulldata` or `nonstandard` script types (see the `type` key below)"
+
+- n: "{{DEPTH}} → → → →<br>`type`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script<br>• `pubkeyhash` for a P2PKH script<br>• `scripthash` for a P2SH script<br>• `multisig` for a bare multisig script<br>• `nulldata` for nulldata scripts<br>• `nonstandard` for unknown scripts"
+
+- n: "{{DEPTH}} → → → →<br>`addresses`"
+  t: "string : array"
+  p: "Optional<br>(0 or 1)"
+  d: "The P2PKH or P2SH addresses used in this transaction, or the computed P2PKH address of any pubkeys in this transaction.  This array will not be returned for `nulldata` or `nonstandard` script types"
+
+- n: "{{DEPTH}} → → → → →<br>Address"
+  t: "string"
+  p: "Required<br>(1 or more)"
+  d: "A P2PKH or P2SH address"
+
 {% endcapture %}
 
 {% assign INCLUDE_WALLET_UNLOCKED="If the wallet has been encrypted either through the GUI or with the `encryptwallet` RPC, it must first be unlocked with the `walletpassphrase` RPC" %}
 
 {% capture INCLUDE_CONFIRMATIONS_PARAMETER %}
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Confirmations      | number (int)    | Optional<br>(0 or 1)        | The minimum number of confirmations an externally-generated transaction must have before it is counted towards the balance.  Transactions generated by this node are counted immediately.  Typically, externally-generated transactions are payments to this wallet and transactions generated by this node are payments to other wallets.  Use `0` to count unconfirmed transactions.  Default is `1`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Confirmations"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The minimum number of confirmations an externally-generated transaction must have before it is counted towards the balance.  Transactions generated by this node are counted immediately.  Typically, externally-generated transactions are payments to this wallet and transactions generated by this node are payments to other wallets.  Use `0` to count unconfirmed transactions.  Default is `1`"
+
+{% enditemplate %}
 {% endcapture %}
 
 {% capture INCLUDE_INCLUDE_WATCH_ONLY_PARAMETER %}
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Include Watch-Only | bool            | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>If set to `true`, include watch-only addresses in details and calculations as if they were regular addresses belonging to the wallet.  If set to `false` (the default), treat watch-only addresses as if they didn't belong to this wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Include Watch-Only"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>If set to `true`, include watch-only addresses in details and calculations as if they were regular addresses belonging to the wallet.  If set to `false` (the default), treat watch-only addresses as if they didn't belong to this wallet"
+
+{% enditemplate %}
 {% endcapture %}
 
 {% assign WARNING="![Warning icon](/img/icons/icon_warning.svg) **Warning:**" %}

--- a/_includes/ref/bitcoin-core/rest/requests/get_block-notxdetails.md
+++ b/_includes/ref/bitcoin-core/rest/requests/get_block-notxdetails.md
@@ -21,39 +21,108 @@ GET /block/notxdetails/<hash>.<format>
 
 *Parameter #1---the header hash of the block to retrieve*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Header Hash      | path (hex)   | Required<br>(exactly 1)     | The hash of the header of the block to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Header Hash"
+  t: "path (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the block to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---the output format*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Format           | suffix       | Required<br>(exactly 1)     | Set to `.json` for decoded block contents in JSON, or `.bin` or `hex` for a serialized block in binary or hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Format"
+  t: "suffix"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `.json` for decoded block contents in JSON, or `.bin` or `hex` for a serialized block in binary or hex"
+
+{% enditemplate %}
 
 *Response as JSON*
 
-| Name                     | Type              | Presence                    | Description
-|--------------------------|-------------------|-----------------------------|----------------
-| Result                   | object            | Required<br>(exactly 1)     | An object containing the requested block
-| →<br>`hash`              | string (hex)      | Required<br>(exactly 1)     | The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1
-| →<br>`confirmations`     | number (int)      | Required<br>(exactly 1)     | The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain
-| →<br>`size`              | number (int)      | Required<br>(exactly 1)     | The size of this block in serialized block format, counted in bytes
-| →<br>`height`            | number (int)      | Required<br>(exactly 1)     | The height of this block on its block chain
-| →<br>`version`           | number (int)      | Required<br>(exactly 1)     | This block's version number.  See [block version numbers][section block versions]
-| →<br>`merkleroot`        | string (hex)      | Required<br>(exactly 1)     | The merkle root for this block, encoded as hex in RPC byte order
-| →<br>`tx`                | array             | Required<br>(exactly 1)     | An array containing all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block
-| → →<br>TXID              | string (hex)      | Required<br>(1 or more)     | The TXID of a transaction in this block, encoded as hex in RPC byte order
-| →<br>`time`              | number (int)      | Required<br>(exactly 1)     | The value of the *time* field in the block header, indicating approximately when the block was created
-| →<br>`nonce`             | number (int)      | Required<br>(exactly 1)     | The nonce which was successful at turning this particular block into one that could be added to the best block chain
-| →<br>`bits`              | string (hex)      | Required<br>(exactly 1)     | The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass
-| →<br>`difficulty`        | number (real)     | Required<br>(exactly 1)     | The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0
-| →<br>`chainwork`         | string (hex)      | Required<br>(exactly 1)     | The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex
-| →<br>`previousblockhash` | string (hex)      | Required<br>(exactly 1)     | The hash of the header of the previous block, encoded as hex in RPC byte order
-| →<br>`nextblockhash`     | string (hex)      | Optional<br>(0 or 1)        | The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Result"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing the requested block"
+
+- n: "→<br>`hash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain"
+
+- n: "→<br>`size`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The size of this block in serialized block format, counted in bytes"
+
+- n: "→<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of this block on its block chain"
+
+- n: "→<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "This block's version number.  See [block version numbers][section block versions]"
+
+- n: "→<br>`merkleroot`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The merkle root for this block, encoded as hex in RPC byte order"
+
+- n: "→<br>`tx`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block"
+
+- n: "→ →<br>TXID"
+  t: "string (hex)"
+  p: "Required<br>(1 or more)"
+  d: "The TXID of a transaction in this block, encoded as hex in RPC byte order"
+
+- n: "→<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *time* field in the block header, indicating approximately when the block was created"
+
+- n: "→<br>`nonce`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The nonce which was successful at turning this particular block into one that could be added to the best block chain"
+
+- n: "→<br>`bits`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0"
+
+- n: "→<br>`chainwork`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex"
+
+- n: "→<br>`previousblockhash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the previous block, encoded as hex in RPC byte order"
+
+- n: "→<br>`nextblockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rest/requests/get_block.md
+++ b/_includes/ref/bitcoin-core/rest/requests/get_block.md
@@ -21,43 +21,112 @@ GET /block/<hash>.<format>
 
 *Parameter #1---the header hash of the block to retrieve*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Header Hash      | path (hex)   | Required<br>(exactly 1)     | The hash of the header of the block to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Header Hash"
+  t: "path (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the block to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---the output format*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Format           | suffix       | Required<br>(exactly 1)     | Set to `.json` for decoded block contents in JSON, or `.bin` or `hex` for a serialized block in binary or hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Format"
+  t: "suffix"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `.json` for decoded block contents in JSON, or `.bin` or `hex` for a serialized block in binary or hex"
+
+{% enditemplate %}
 
 *Response as JSON*
 
 {% assign DEPTH="→ →" %}
 {% include helpers/vars.md %}
 
-| Name                     | Type              | Presence                    | Description
-|--------------------------|-------------------|-----------------------------|----------------
-| Result                   | object            | Required<br>(exactly 1)     | An object containing the requested block
-| →<br>`hash`              | string (hex)      | Required<br>(exactly 1)     | The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1
-| →<br>`confirmations`     | number (int)      | Required<br>(exactly 1)     | The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain
-| →<br>`size`              | number (int)      | Required<br>(exactly 1)     | The size of this block in serialized block format, counted in bytes
-| →<br>`height`            | number (int)      | Required<br>(exactly 1)     | The height of this block on its block chain
-| →<br>`version`           | number (int)      | Required<br>(exactly 1)     | This block's version number.  See [block version numbers][section block versions]
-| →<br>`merkleroot`        | string (hex)      | Required<br>(exactly 1)     | The merkle root for this block, encoded as hex in RPC byte order
-| →<br>`tx`                | array             | Required<br>(exactly 1)     | An array containing all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block
-| → →<br>Transaction       | object            | Required<br>(1 or more)     | An object describing a particular transaction within this block
+{% itemplate ntpd1 %}
+- n: "Result"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing the requested block"
+
+- n: "→<br>`hash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain"
+
+- n: "→<br>`size`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The size of this block in serialized block format, counted in bytes"
+
+- n: "→<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of this block on its block chain"
+
+- n: "→<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "This block's version number.  See [block version numbers][section block versions]"
+
+- n: "→<br>`merkleroot`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The merkle root for this block, encoded as hex in RPC byte order"
+
+- n: "→<br>`tx`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block"
+
+- n: "→ →<br>Transaction"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing a particular transaction within this block"
+
 {{INCLUDE_DECODE_RAW_TRANSACTION}}
-| →<br>`time`              | number (int)      | Required<br>(exactly 1)     | The value of the *time* field in the block header, indicating approximately when the block was created
-| →<br>`nonce`             | number (int)      | Required<br>(exactly 1)     | The nonce which was successful at turning this particular block into one that could be added to the best block chain
-| →<br>`bits`              | string (hex)      | Required<br>(exactly 1)     | The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass
-| →<br>`difficulty`        | number (real)     | Required<br>(exactly 1)     | The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0
-| →<br>`chainwork`         | string (hex)      | Required<br>(exactly 1)     | The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex
-| →<br>`previousblockhash` | string (hex)      | Required<br>(exactly 1)     | The hash of the header of the previous block, encoded as hex in RPC byte order
-| →<br>`nextblockhash`     | string (hex)      | Optional<br>(0 or 1)        | The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order
-{:.ntpd}
+- n: "→<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *time* field in the block header, indicating approximately when the block was created"
+
+- n: "→<br>`nonce`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The nonce which was successful at turning this particular block into one that could be added to the best block chain"
+
+- n: "→<br>`bits`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0"
+
+- n: "→<br>`chainwork`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex"
+
+- n: "→<br>`previousblockhash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the previous block, encoded as hex in RPC byte order"
+
+- n: "→<br>`nextblockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rest/requests/get_tx.md
+++ b/_includes/ref/bitcoin-core/rest/requests/get_tx.md
@@ -23,32 +23,57 @@ GET /tx/<txid>.<format>
 
 *Parameter #1---the TXID of the transaction to retrieve*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| TXID             | path (hex)   | Required<br>(exactly 1)     | The TXID of the transaction to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "TXID"
+  t: "path (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---the output format*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Format           | suffix       | Required<br>(exactly 1)     | Set to `.json` for decoded transaction contents in JSON, or `.bin` or `hex` for a serialized transaction in binary or hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Format"
+  t: "suffix"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `.json` for decoded transaction contents in JSON, or `.bin` or `hex` for a serialized transaction in binary or hex"
+
+{% enditemplate %}
 
 *Response as JSON*
 
 {% assign DEPTH="" %}
 {% include helpers/vars.md %}
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| Result               | object          | Required<br>(exactly 1)     | An object describing the request transaction
+{% itemplate ntpd1 %}
+- n: "Result"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the request transaction"
+
 {{INCLUDE_DECODE_RAW_TRANSACTION}}
-| →<br>`blockhash`     | string (hex)    | Optional<br>(0 or 1)        | If the transaction has been included in a block on the local best block chain, this is the hash of that block encoded as hex in RPC byte order
-| →<br>`confirmations` | number (int)    | Required<br>(exactly 1)     | If the transaction has been included in a block on the local best block chain, this is how many confirmations it has.  Otherwise, this is `0`
-| →<br>`time`          | number (int)    | Optional<br>(0 or 1)        | If the transaction has been included in a block on the local best block chain, this is the block header time of that block (may be in the future)
-| →<br>`blocktime`     | number (int)    | Optional<br>(0 or 1)        | This field is currently identical to the time field described above
-{:.ntpd}
+- n: "→<br>`blockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is the hash of that block encoded as hex in RPC byte order"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is how many confirmations it has.  Otherwise, this is `0`"
+
+- n: "→<br>`time`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is the block header time of that block (may be in the future)"
+
+- n: "→<br>`blocktime`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "This field is currently identical to the time field described above"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/addmultisigaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/addmultisigaddress.md
@@ -17,32 +17,48 @@ The `addmultisigaddress` RPC {{summary_addMultiSigAddress}}
 
 *Parameter #1---the number of signatures required*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Required           | number (int)    | Required<br>(exactly 1)     | The minimum (*m*) number of signatures required to spend this m-of-n multisig script
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Required"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The minimum (*m*) number of signatures required to spend this m-of-n multisig script"
+
+{% enditemplate %}
 
 *Parameter #2---the full public keys, or addresses for known public keys*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| Keys Or Addresses   | array           | Required<br>(exactly 1)     | An array of strings with each string being a public key or address
-| →<br>Key Or Address | string          | Required<br>(1 or more)     | A public key against which signatures will be checked.  Alternatively, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Keys Or Addresses"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of strings with each string being a public key or address"
+
+- n: "→<br>Key Or Address"
+  t: "string"
+  p: "Required<br>(1 or more)"
+  d: "A public key against which signatures will be checked.  Alternatively, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys"
+
+{% enditemplate %}
 
 *Parameter #3---the account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | The account name in which the address should be stored.  Default is the default account, "" (an empty string)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The account name in which the address should be stored.  Default is the default account, \"\" (an empty string)"
+
+{% enditemplate %}
 
 *Result---a P2SH address printed and stored in the wallet*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | The P2SH multisig address.  The address will also be added to the wallet, and outputs paying that address will be tracked by the wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2SH multisig address.  The address will also be added to the wallet, and outputs paying that address will be tracked by the wallet"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/addnode.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/addnode.md
@@ -15,24 +15,33 @@ The `addnode` RPC {{summary_addNode}}
 
 *Parameter #1---hostname/IP address and port of node to add or remove*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Node               | string          | Required<br>(exactly 1)     | The node to add as a string in the form of `<IP address>:<port>`.  The IP address may be a hostname resolvable through DNS, an IPv4 address, an IPv4-as-IPv6 address, or an IPv6 address
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Node"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The node to add as a string in the form of `<IP address>:<port>`.  The IP address may be a hostname resolvable through DNS, an IPv4 address, an IPv4-as-IPv6 address, or an IPv6 address"
+
+{% enditemplate %}
 
 *Parameter #2---whether to add or remove the node, or to try only once to connect*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Command            | string          | Required<br>(exactly 1)     | What to do with the IP address above.  Options are:<br>• `add` to add a node to the addnode list.  This will not connect immediately if the outgoing connection slots are full<br>• `remove` to remove a node from the list.  If currently connected, this will disconnect immediately<br>• `onetry` to immediately attempt connection to the node even if the outgoing connection slots are full; this will only attempt the connection once
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Command"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "What to do with the IP address above.  Options are:<br>• `add` to add a node to the addnode list.  This will not connect immediately if the outgoing connection slots are full<br>• `remove` to remove a node from the list.  If currently connected, this will disconnect immediately<br>• `onetry` to immediately attempt connection to the node even if the outgoing connection slots are full; this will only attempt the connection once"
+
+{% enditemplate %}
 
 *Result---`null` plus error on failed remove*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | null            | Required<br>(exactly 1)     | Always JSON `null` whether the node was added, removed, tried-and-connected, or tried-and-not-connected.  The JSON-RPC error field will be set only if you try removing a node that is not on the addnodes list
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always JSON `null` whether the node was added, removed, tried-and-connected, or tried-and-not-connected.  The JSON-RPC error field will be set only if you try removing a node that is not on the addnodes list"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/backupwallet.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/backupwallet.md
@@ -17,17 +17,23 @@ The `backupwallet` RPC {{summary_backupWallet}}
 
 *Parameter #1---destination directory or filename*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Destination        | string          | Required<br>(exactly 1)     | A filename or directory name.  If a filename, it will be created or overwritten.  If a directory name, the file `wallet.dat`<!--noref--> will be created or overwritten within that directory
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Destination"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A filename or directory name.  If a filename, it will be created or overwritten.  If a directory name, the file `wallet.dat`<!--noref--> will be created or overwritten within that directory"
+
+{% enditemplate %}
 
 *Result---`null` or error*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | Always `null` whether success or failure.  The JSON-RPC error and message fields will be set if a failure occurred
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always `null` whether success or failure.  The JSON-RPC error and message fields will be set if a failure occurred"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/createmultisig.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/createmultisig.md
@@ -15,27 +15,48 @@ The `createmultisig` RPC {{summary_createMultiSig}}
 
 *Parameter #1---the number of signatures required*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Required           | number (int)    | Required<br>(exactly 1)     | The minimum (*m*) number of signatures required to spend this m-of-n multisig script
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Required"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The minimum (*m*) number of signatures required to spend this m-of-n multisig script"
+
+{% enditemplate %}
 
 *Parameter #2---the full public keys, or addresses for known public keys*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| Keys Or Addresses   | array           | Required<br>(exactly 1)     | An array of strings with each string being a public key or address
-| →<br>Key Or Address | string          | Required<br>(1 or more)     | A public key against which signatures will be checked.  If wallet support is enabled, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Keys Or Addresses"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of strings with each string being a public key or address"
+
+- n: "→<br>Key Or Address"
+  t: "string"
+  p: "Required<br>(1 or more)"
+  d: "A public key against which signatures will be checked.  If wallet support is enabled, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys"
+
+{% enditemplate %}
 
 *Result---P2SH address and hex-encoded redeem script*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| `result`            | object          | Required<br>(exactly 1)     | An object describing the multisig address
-| →<br>`address`      | string (base58) | Required<br>(exactly 1)     | The P2SH address for this multisig redeem script
-| →<br>`redeemScript` | string (hex)    | Required<br>(exactly 1)     | The multisig redeem script encoded as hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the multisig address"
+
+- n: "→<br>`address`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2SH address for this multisig redeem script"
+
+- n: "→<br>`redeemScript`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The multisig redeem script encoded as hex"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/createrawtransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/createrawtransaction.md
@@ -15,28 +15,53 @@ The `createrawtransaction` RPC {{summary_createRawTransaction}}
 
 *Parameter #1---references to previous outputs*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Outpoints          | array           | Required<br>(exactly 1)     | An array of objects, each one being an unspent outpoint
-| → Outpoint         | object          | Required<br>(1 or more)     | An object describing a particular unspent outpoint
-| → →<br>`txid`      | string (hex)    | Required<br>(exactly 1)     | The TXID of the outpoint encoded as hex in RPC byte order
-| → →<br>`vout`      | number (int)    | Required<br>(exactly 1)     | The output index number (vout) of the outpoint; the first output in a transaction is index `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Outpoints"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects, each one being an unspent outpoint"
+
+- n: "→ Outpoint"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing a particular unspent outpoint"
+
+- n: "→ →<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the outpoint encoded as hex in RPC byte order"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number (vout) of the outpoint; the first output in a transaction is index `0`"
+
+{% enditemplate %}
 
 *Parameter #2---P2PKH or P2SH addresses and amounts*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| Outputs             | object          | Required<br>(exactly 1)     | The addresses and amounts to pay
-| →<br>Address/Amount | string : number (bitcoins) | Required<br>(1 or more) | A key/value pair with the address to pay as a string (key) and the amount to pay that address (value) in bitcoins
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Outputs"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "The addresses and amounts to pay"
+
+- n: "→<br>Address/Amount"
+  t: "string : number (bitcoins)"
+  p: "Required<br>(1 or more)"
+  d: "A key/value pair with the address to pay as a string (key) and the amount to pay that address (value) in bitcoins"
+
+{% enditemplate %}
 
 *Result---the unsigned raw transaction in hex*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string          | Required<br>(Exactly 1)     | The resulting unsigned raw transaction in serialized transaction format encoded as hex.  If the transaction couldn't be generated, this will be set to JSON `null` and the JSON-RPC error field may contain an error message
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(Exactly 1)"
+  d: "The resulting unsigned raw transaction in serialized transaction format encoded as hex.  If the transaction couldn't be generated, this will be set to JSON `null` and the JSON-RPC error field may contain an error message"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/decoderawtransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/decoderawtransaction.md
@@ -15,18 +15,24 @@ The `decoderawtransaction` RPC {{summary_decodeRawTransaction}}
 
 *Parameter #1---serialized transaction in hex*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Serialized Transaction | string (hex) | Required<br>(exactly 1)    | The transaction to decode in serialized transaction format
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Serialized Transaction"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction to decode in serialized transaction format"
+
+{% enditemplate %}
 
 *Result---the decoded transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | object          | Required<br>(exactly 1)     | An object describing the decoded transaction, or JSON `null` if the transaction could not be decoded
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the decoded transaction, or JSON `null` if the transaction could not be decoded"
+
 {{INCLUDE_DECODE_RAW_TRANSACTION}}
-{:.ntpd}
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/decodescript.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/decodescript.md
@@ -15,23 +15,53 @@ The `decodescript` RPC {{summary_decodeScript}}
 
 *Parameter #1---a hex-encoded redeem script*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Redeem Script      | string (hex)    | Required<br>(exactly 1)     | The redeem script to decode as a hex-encoded serialized script
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Redeem Script"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The redeem script to decode as a hex-encoded serialized script"
+
+{% enditemplate %}
 
 *Result---the decoded script*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | object          | Required<br>(exactly 1)     | An object describing the decoded script, or JSON `null` if the script could not be decoded
-| →<br>`asm`         | string          | Required<br>(exactly 1)     | The redeem script in decoded form with non-data-pushing op codes listed.  May be empty
-| →<br>`type`        | string          | Optional<br>(0 or 1)        | The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script inside P2SH<br>• `pubkeyhash` for a P2PKH script inside P2SH<br>• `multisig` for a multisig script inside P2SH<br>• `nonstandard` for unknown scripts
-| →<br>`reqSigs`     | number (int)    | Optional<br>(0 or 1)        | The number of signatures required; this is always `1` for P2PK or P2PKH within P2SH.  It may be greater than 1 for P2SH multisig.  This value will not be returned for `nonstandard` script types (see the `type` key above)
-| →<br>`addresses`   | array           | Optional<br>(0 or 1)        | A P2PKH addresses used in this script, or the computed P2PKH addresses of any pubkeys in this script.  This array will not be returned for `nonstandard` script types
-| → →<br>Address     | string          | Required<br>(1 or more)     | A P2PKH address
-| →<br>`p2sh`        | string (hex)    | Required<br>(exactly 1)     | The P2SH address of this redeem script
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the decoded script, or JSON `null` if the script could not be decoded"
+
+- n: "→<br>`asm`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The redeem script in decoded form with non-data-pushing op codes listed.  May be empty"
+
+- n: "→<br>`type`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script inside P2SH<br>• `pubkeyhash` for a P2PKH script inside P2SH<br>• `multisig` for a multisig script inside P2SH<br>• `nonstandard` for unknown scripts"
+
+- n: "→<br>`reqSigs`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of signatures required; this is always `1` for P2PK or P2PKH within P2SH.  It may be greater than 1 for P2SH multisig.  This value will not be returned for `nonstandard` script types (see the `type` key above)"
+
+- n: "→<br>`addresses`"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "A P2PKH addresses used in this script, or the computed P2PKH addresses of any pubkeys in this script.  This array will not be returned for `nonstandard` script types"
+
+- n: "→ →<br>Address"
+  t: "string"
+  p: "Required<br>(1 or more)"
+  d: "A P2PKH address"
+
+- n: "→<br>`p2sh`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2SH address of this redeem script"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/dumpprivkey.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/dumpprivkey.md
@@ -18,17 +18,23 @@ The `dumpprivkey` RPC {{summary_dumpPrivKey}}
 
 *Parameter #1---the address corresponding to the private key to get*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| P2PKH Address      | string (base58) | Required<br>(exactly 1)     | The P2PKH address corresponding to the private key you want returned.  Must be the address corresponding to a private key in this wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "P2PKH Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2PKH address corresponding to the private key you want returned.  Must be the address corresponding to a private key in this wallet"
+
+{% enditemplate %}
 
 *Result---the private key*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | The private key encoded as base58check using wallet import format
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The private key encoded as base58check using wallet import format"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/dumpwallet.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/dumpwallet.md
@@ -18,17 +18,23 @@ The `dumpwallet` RPC {{summary_dumpWallet}}
 
 *Parameter #1---a filename*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Filename           | string          | Required<br>(exactly 1)     | The file in which the wallet dump will be placed.  May be prefaced by an absolute file path.  An existing file with that name will be overwritten
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Filename"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The file in which the wallet dump will be placed.  May be prefaced by an absolute file path.  An existing file with that name will be overwritten"
+
+{% enditemplate %}
 
 *Result---`null` or error*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | Always `null` whether success or failure.  The JSON-RPC error and message fields will be set if a failure occurred
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always `null` whether success or failure.  The JSON-RPC error and message fields will be set if a failure occurred"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/encryptwallet.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/encryptwallet.md
@@ -24,17 +24,23 @@ the `dumpwallet` RPC.
 
 *Parameter #1---a passphrase*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Passphrase         | string          | Required<br>(exactly 1)     | The passphrase to use for the encrypted wallet.  Must be at least one character
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Passphrase"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The passphrase to use for the encrypted wallet.  Must be at least one character"
+
+{% enditemplate %}
 
 *Result---a notice (with program shutdown)*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string          | Required<br>(exactly 1)     | A notice that the server is stopping and that you need to make a new backup.  The wallet is now encrypted
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A notice that the server is stopping and that you need to make a new backup.  The wallet is now encrypted"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/estimatefee.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/estimatefee.md
@@ -17,17 +17,23 @@ The `estimatefee` RPC {{summary_estimateFee}}
 
 *Parameter #1---how many blocks the transaction may wait before being included*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Blocks             | number (int)    | Required<br>(exactly 1)     | The maximum number of blocks a transaction should have to wait before it is predicted to be included in a block
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Blocks"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The maximum number of blocks a transaction should have to wait before it is predicted to be included in a block"
+
+{% enditemplate %}
 
 *Result---the fee the transaction needs to pay per kilobyte*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (bitcoins) | Required<br>(exactly 1)     | The estimated fee the transaction should pay in order to be included within the specified number of blocks.  If the node doesn't have enough information to make an estimate, the value `-1` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated fee the transaction should pay in order to be included within the specified number of blocks.  If the node doesn't have enough information to make an estimate, the value `-1` will be returned"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/estimatepriority.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/estimatepriority.md
@@ -19,17 +19,23 @@ Transaction priority is relative to a transaction's byte size.
 
 *Parameter #1---how many blocks the transaction may wait before being included as a free high-priority transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Blocks             | number (int)    | Required<br>(exactly 1)     | The maximum number of blocks a transaction should have to wait before it is predicted to be included in a block based purely on its priority
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Blocks"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The maximum number of blocks a transaction should have to wait before it is predicted to be included in a block based purely on its priority"
+
+{% enditemplate %}
 
 *Result---the priority a transaction needs*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (real)     | Required<br>(exactly 1)     | The estimated priority the transaction should have in order to be included within the specified number of blocks.  If the node doesn't have enough information to make an estimate, the value `-1` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated priority the transaction should have in order to be included within the specified number of blocks.  If the node doesn't have enough information to make an estimate, the value `-1` will be returned"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getaccount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getaccount.md
@@ -17,17 +17,23 @@ The `getaccount` RPC {{summary_getAccount}}
 
 *Parameter #1---a Bitcoin address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Address            | string (base58) | Required<br>(exactly 1)     | A P2PKH or P2SH Bitcoin address belonging either to a specific account or the default account ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH or P2SH Bitcoin address belonging either to a specific account or the default account (\"\")"
+
+{% enditemplate %}
 
 *Result---an account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string          | Required<br>(exactly 1)     | The name of an account, or an empty string ("", the default account)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of an account, or an empty string (\"\", the default account)"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getaccountaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getaccountaddress.md
@@ -17,17 +17,23 @@ The `getaccountaddress` RPC {{summary_getAccountAddress}}
 
 *Parameter #1---an account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Required<br>(exactly 1)     | The name of an account.  Use an empty string ("") for the default account.  If the account doesn't exist, it will be created
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of an account.  Use an empty string (\"\") for the default account.  If the account doesn't exist, it will be created"
+
+{% enditemplate %}
 
 *Result---a bitcoin address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | An address, belonging to the account specified, which has not yet received any payments
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "An address, belonging to the account specified, which has not yet received any payments"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getaddednodeinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getaddednodeinfo.md
@@ -15,31 +15,68 @@ The `getaddednodeinfo` RPC {{summary_getAddedNodeInfo}}
 
 *Parameter #1---whether to display connection information*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Details          | bool         | Required<br>(exactly 1)     | Set to `true` to display detailed information about each added node; set to `false` to only display the IP address or hostname and port added
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Details"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` to display detailed information about each added node; set to `false` to only display the IP address or hostname and port added"
+
+{% enditemplate %}
 
 *Parameter #2---what node to display information about*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Node             | string       | Optional<br>(0 or 1)        | The node to get information about in the same `<IP address>:<port>` format as the `addnode` RPC.  If this parameter is not provided, information about all added nodes will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Node"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The node to get information about in the same `<IP address>:<port>` format as the `addnode` RPC.  If this parameter is not provided, information about all added nodes will be returned"
+
+{% enditemplate %}
 
 *Result---a list of added nodes*
 
-| Name                   | Type         | Presence                    | Description
-|------------------------|--------------|-----------------------------|----------------
-| `result`               | array        | Required<br>(exactly 1)     | An array containing objects describing each added node.  If no added nodes are present, the array will be empty.  Nodes added with `onetry` will not be returned
-| →<br>Added Node        | object       | Optional<br>(0 or more)     | An object containing details about a single added node
-| → →<br>`addednode`     | string       | Required<br>(exactly 1)     | An added node in the same `<IP address>:<port>` format as used in the `addnode` RPC.  This element is present for any added node whether or not the Details parameter was set to `true`
-| → →<br>`connected`     | bool         | Optional<br>(0 or 1)        | If the Details parameter was set to `true`, this will be set to `true` if the node is currently connected and `false` if it is not
-| → →<br>`addresses`     | array        | Optional<br>(0 or 1)        | If the Details parameter was set to `true`, this will be an array of addresses belonging to the added node
-| → → →<br>Address       | object       | Optional<br>(0 or more)     | An object describing one of this node's addresses
-| → → → →<br>`address`   | string       | Required<br>(exactly 1)     | An IP address and port number of the node.  If the node was added using a DNS address, this will be the resolved IP address
-| → → → →<br>`connected` | string       | Required<br>(exactly 1)     | Whether or not the local node is connected to this addnode using this IP address.  Valid values are:<br>• `false` for not connected<br>• `inbound` if the addnode connected to us<br>• `outbound` if we connected to the addnode
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing objects describing each added node.  If no added nodes are present, the array will be empty.  Nodes added with `onetry` will not be returned"
+
+- n: "→<br>Added Node"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object containing details about a single added node"
+
+- n: "→ →<br>`addednode`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "An added node in the same `<IP address>:<port>` format as used in the `addnode` RPC.  This element is present for any added node whether or not the Details parameter was set to `true`"
+
+- n: "→ →<br>`connected`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "If the Details parameter was set to `true`, this will be set to `true` if the node is currently connected and `false` if it is not"
+
+- n: "→ →<br>`addresses`"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "If the Details parameter was set to `true`, this will be an array of addresses belonging to the added node"
+
+- n: "→ → →<br>Address"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object describing one of this node's addresses"
+
+- n: "→ → → →<br>`address`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "An IP address and port number of the node.  If the node was added using a DNS address, this will be the resolved IP address"
+
+- n: "→ → → →<br>`connected`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "Whether or not the local node is connected to this addnode using this IP address.  Valid values are:<br>• `false` for not connected<br>• `inbound` if the addnode connected to us<br>• `outbound` if we connected to the addnode"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getaddressesbyaccount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getaddressesbyaccount.md
@@ -17,18 +17,28 @@ The `getaddressesbyaccount` RPC {{summary_getAddressesByAccount}}
 
 *Parameter #1---the account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Required<br>(exactly 1)     | The name of the account containing the addresses to get.  To get addresses from the default account, pass an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account containing the addresses to get.  To get addresses from the default account, pass an empty string (\"\")"
+
+{% enditemplate %}
 
 *Result---a list of addresses*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | array           | Required<br>(exactly 1)     | An array containing all addresses belonging to the specified account.  If the account has no addresses, the array will be empty
-| Address            | string (base58) | Optional<br>(1 or more) | A P2PKH or P2SH address belonging to the account
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing all addresses belonging to the specified account.  If the account has no addresses, the array will be empty"
+
+- n: "Address"
+  t: "string (base58)"
+  p: "Optional<br>(1 or more)"
+  d: "A P2PKH or P2SH address belonging to the account"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getbalance.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getbalance.md
@@ -17,10 +17,13 @@ The `getbalance` RPC {{summary_getBalance}}
 
 *Parameter #1---an account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | The name of an account to get the balance for.  An empty string ("") is the default account.  The string `*` will get the balance for all accounts (this is the default behavior)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The name of an account to get the balance for.  An empty string (\"\") is the default account.  The string `*` will get the balance for all accounts (this is the default behavior)"
+
+{% enditemplate %}
 
 *Parameter #2---the minimum number of confirmations*
 
@@ -32,10 +35,13 @@ The `getbalance` RPC {{summary_getBalance}}
 
 *Result---the balance in bitcoins*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (bitcoins) | Required<br>(exactly 1)     | The balance of the account (or all accounts) in bitcoins
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The balance of the account (or all accounts) in bitcoins"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getbestblockhash.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getbestblockhash.md
@@ -19,10 +19,13 @@ The `getbestblockhash` RPC {{summary_getBestBlockHash}}
 
 *Result---hash of the tip from the best block chain*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| `result`         | string (hex) | Required<br>(exactly 1)     | The hash of the block header from the most recent block on the best block chain, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the block header from the most recent block on the best block chain, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getblock.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getblock.md
@@ -15,46 +15,118 @@ The `getblock` RPC {{summary_getBlock}}
 
 *Parameter #1---header hash*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Header Hash      | string (hex) | Required<br>(exactly 1)     | The hash of the header of the block to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Header Hash"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the block to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---JSON or hex output*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Format           | bool         | Optional<br>(0 or 1)        | Set to `false` to get the block in serialized block format; set to `true` (the default) to get the decoded block as a JSON object
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Format"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `false` to get the block in serialized block format; set to `true` (the default) to get the decoded block as a JSON object"
+
+{% enditemplate %}
 
 *Result (if format was `false`)---a serialized block*
 
-| Name             | Type              | Presence                    | Description
-|------------------|-------------------|-----------------------------|----------------
-| `result`         | string (hex)/null | Required<br>(exactly 1)     | The requested block as a serialized block, encoded as hex, or JSON `null` if an error occurred
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (hex)/null"
+  p: "Required<br>(exactly 1)"
+  d: "The requested block as a serialized block, encoded as hex, or JSON `null` if an error occurred"
+
+{% enditemplate %}
 
 *Result (if format was `true` or omitted)---a JSON block*
 
-| Name                       | Type            | Presence                    | Description
-|----------------------------|-------------------|---------------------------|----------------
-| `result`                   | object/null       | Required<br>(exactly 1)   | An object containing the requested block, or JSON `null` if an error occurred
-| →<br>`hash`              | string (hex)      | Required<br>(exactly 1)     | The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1
-| →<br>`confirmations`     | number (int)      | Required<br>(exactly 1)     | The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain
-| →<br>`size`              | number (int)      | Required<br>(exactly 1)     | The size of this block in serialized block format, counted in bytes
-| →<br>`height`            | number (int)      | Required<br>(exactly 1)     | The height of this block on its block chain
-| →<br>`version`           | number (int)      | Required<br>(exactly 1)     | This block's version number.  See [block version numbers][section block versions]
-| →<br>`merkleroot`        | string (hex)      | Required<br>(exactly 1)     | The merkle root for this block, encoded as hex in RPC byte order
-| →<br>`tx`                | array             | Required<br>(exactly 1)     | An array containing the TXIDs of all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block
-| → →<br>TXID              | string (hex)      | Required<br>(1 or more)     | The TXID of a transaction in this block, encoded as hex in RPC byte order
-| →<br>`time`              | number (int)      | Required<br>(exactly 1)     | The value of the *time* field in the block header, indicating approximately when the block was created
-| →<br>`nonce`             | number (int)      | Required<br>(exactly 1)     | The nonce which was successful at turning this particular block into one that could be added to the best block chain
-| →<br>`bits`              | string (hex)      | Required<br>(exactly 1)     | The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass
-| →<br>`difficulty`        | number (real)     | Required<br>(exactly 1)     | The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0
-| →<br>`chainwork`         | string (hex)      | Required<br>(exactly 1)     | The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex
-| →<br>`previousblockhash` | string (hex)      | Required<br>(exactly 1)     | The hash of the header of the previous block, encoded as hex in RPC byte order
-| →<br>`nextblockhash`     | string (hex)      | Optional<br>(0 or 1)        | The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object/null"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing the requested block, or JSON `null` if an error occurred"
+
+- n: "→<br>`hash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of this block's block header encoded as hex in RPC byte order.  This is the same as the hash provided in parameter #1"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations the transactions in this block have, starting at 1 when this block is at the tip of the best block chain.  This score will be -1 if the the block is not part of the best block chain"
+
+- n: "→<br>`size`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The size of this block in serialized block format, counted in bytes"
+
+- n: "→<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of this block on its block chain"
+
+- n: "→<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "This block's version number.  See [block version numbers][section block versions]"
+
+- n: "→<br>`merkleroot`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The merkle root for this block, encoded as hex in RPC byte order"
+
+- n: "→<br>`tx`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing the TXIDs of all transactions in this block.  The transactions appear in the array in the same order they appear in the serialized block"
+
+- n: "→ →<br>TXID"
+  t: "string (hex)"
+  p: "Required<br>(1 or more)"
+  d: "The TXID of a transaction in this block, encoded as hex in RPC byte order"
+
+- n: "→<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *time* field in the block header, indicating approximately when the block was created"
+
+- n: "→<br>`nonce`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The nonce which was successful at turning this particular block into one that could be added to the best block chain"
+
+- n: "→<br>`bits`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The value of the *nBits* field in the block header, indicating the target threshold this block's header had to pass"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated amount of work done to find this block relative to the estimated amount of work done to find block 0"
+
+- n: "→<br>`chainwork`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated number of block header hashes miners had to check from the genesis block to this block, encoded as big-endian hex"
+
+- n: "→<br>`previousblockhash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the previous block, encoded as hex in RPC byte order"
+
+- n: "→<br>`nextblockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The hash of the next block on the best block chain, if known, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getblockchaininfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getblockchaininfo.md
@@ -19,17 +19,48 @@ The `getblockchaininfo` RPC {{summary_getBlockChainInfo}}
 
 *Result---A JSON object providing information about the block chain*
 
-| Name                        | Type              | Presence                | Description
-|-----------------------------|-------------------|-------------------------|----------------
-| `result`                    | object            | Required<br>(exactly 1) | Information about the current state of the local block chain
-| →<br>`chain`                | string            | Required<br>(exactly 1) | The name of the block chain.  One of `main` for mainnet, `test` for testnet, or `regtest`<!--noref--> for regtest
-| →<br>`blocks`               | number (int)      | Required<br>(exactly 1) | The number of validated blocks in the local best block chain.  For a new node with just the hardcoded genesis block, this will be 0
-| →<br>`headers`              | number (int)      | Required<br>(exactly 1) | *Added in Bitcoin Core 0.10.0*<br><br>The number of validated headers in the local best headers chain.  For a new node with just the hardcoded genesis block, this will be zero.  This number may be higher than the number of *blocks*
-| →<br>`bestblockhash`        | string (hex)      | Required<br>(exactly 1) | The hash of the header of the highest validated block in the best block chain, encoded as hex in RPC byte order.  This is identical to the string returned by the `getbestblockhash` RPC
-| →<br>`difficulty`           | number (real)     | Required<br>(exactly 1) | The difficulty of the highest-height block in the best block chain
-| →<br>`verificationprogress` | number (real)     | Required (exactly 1)    | Estimate of what percentage of the block chain transactions have been verified so far, starting at 0.0 and increasing to 1.0 for fully verified.  May slightly exceed 1.0 when fully synced to account for transactions in the memory pool which have been verified before being included in a block
-| →<br>`chainwork`            | string (hex)      | Required<br>(exactly 1) | The estimated number of block header hashes checked from the genesis block to this block, encoded as big-endian hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Information about the current state of the local block chain"
+
+- n: "→<br>`chain`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the block chain.  One of `main` for mainnet, `test` for testnet, or `regtest`<!--noref--> for regtest"
+
+- n: "→<br>`blocks`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of validated blocks in the local best block chain.  For a new node with just the hardcoded genesis block, this will be 0"
+
+- n: "→<br>`headers`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The number of validated headers in the local best headers chain.  For a new node with just the hardcoded genesis block, this will be zero.  This number may be higher than the number of *blocks*"
+
+- n: "→<br>`bestblockhash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the highest validated block in the best block chain, encoded as hex in RPC byte order.  This is identical to the string returned by the `getbestblockhash` RPC"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The difficulty of the highest-height block in the best block chain"
+
+- n: "→<br>`verificationprogress`"
+  t: "number (real)"
+  p: "Required (exactly 1)"
+  d: "Estimate of what percentage of the block chain transactions have been verified so far, starting at 0.0 and increasing to 1.0 for fully verified.  May slightly exceed 1.0 when fully synced to account for transactions in the memory pool which have been verified before being included in a block"
+
+- n: "→<br>`chainwork`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated number of block header hashes checked from the genesis block to this block, encoded as big-endian hex"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getblockcount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getblockcount.md
@@ -17,10 +17,13 @@ The `getblockcount` RPC {{summary_getBlockCount}}
 
 *Result---the number of blocks in the local best block chain*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | number (int)    | Required<br>(exactly 1)     | The number of blocks in the local best block chain.  For a new node with only the hardcoded genesis block, this number will be 0
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of blocks in the local best block chain.  For a new node with only the hardcoded genesis block, this number will be 0"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getblockhash.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getblockhash.md
@@ -15,17 +15,23 @@ The `getblockhash` RPC {{summary_getBlockHash}}
 
 *Parameter---a block height*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Block Height     | number (int)    | Required<br>(exactly 1)     | The height of the block whose header hash should be returned.  The height of the hardcoded genesis block is 0
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Block Height"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of the block whose header hash should be returned.  The height of the hardcoded genesis block is 0"
+
+{% enditemplate %}
 
 *Result---the block header hash*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | string (hex)/null | Required<br>(exactly 1)   | The hash of the block at the requested height, encoded as hex in RPC byte order, or JSON `null` if an error occurred
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (hex)/null"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the block at the requested height, encoded as hex in RPC byte order, or JSON `null` if an error occurred"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getchaintips.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getchaintips.md
@@ -19,15 +19,38 @@ The `getchaintips` RPC {{summary_getChainTips}}
 
 *Result---an array of block chain tips*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| `result`            | array           | Required<br>(exactly 1)     | An array of JSON objects, with each object describing a chain tip.  At least one tip---the local best block chain---will always be present
-| →<br>Tip            | object          | Required<br>(1 or more)     | An object describing a particular chain tip.  The first object will always describe the active chain (the local best block chain)
-| → →<br>`height`     | number (int)    | Required<br>(exactly 1)     | The height of the highest block in the chain.  A new node with only the genesis block will have a single tip with height of 0
-| → →<br>`hash`       | string (hex)    | Required<br>(exactly 1)     | The hash of the highest block in the chain, encoded as hex in RPC byte order
-| → →<br>`branchlen`  | number (int)    | Required<br>(exactly 1)     | The number of blocks that are on this chain but not on the main chain.  For the local best block chain, this will be `0`; for all other chains, it will be at least `1`
-| → →<br>`status`     | string          | Required<br>(exactly 1)     | The status of this chain.  Valid values are:<br>• `active` for the local best block chain<br>• `invalid` for a chain that contains one or more invalid blocks<br>• `headers-only` for a chain with valid headers whose corresponding blocks both haven't been validated and aren't stored locally<br>• `valid-headers` for a chain with valid headers whose corresponding blocks are stored locally, but which haven't been fully validated<br>• `valid-fork` for a chain which is fully validated but which isn't part of the local best block chain (it was probably the local best block chain at some point)<br>• `unknown` for a chain whose reason for not being the active chain is unknown
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of JSON objects, with each object describing a chain tip.  At least one tip---the local best block chain---will always be present"
+
+- n: "→<br>Tip"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing a particular chain tip.  The first object will always describe the active chain (the local best block chain)"
+
+- n: "→ →<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of the highest block in the chain.  A new node with only the genesis block will have a single tip with height of 0"
+
+- n: "→ →<br>`hash`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the highest block in the chain, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`branchlen`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of blocks that are on this chain but not on the main chain.  For the local best block chain, this will be `0`; for all other chains, it will be at least `1`"
+
+- n: "→ →<br>`status`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The status of this chain.  Valid values are:<br>• `active` for the local best block chain<br>• `invalid` for a chain that contains one or more invalid blocks<br>• `headers-only` for a chain with valid headers whose corresponding blocks both haven't been validated and aren't stored locally<br>• `valid-headers` for a chain with valid headers whose corresponding blocks are stored locally, but which haven't been fully validated<br>• `valid-fork` for a chain which is fully validated but which isn't part of the local best block chain (it was probably the local best block chain at some point)<br>• `unknown` for a chain whose reason for not being the active chain is unknown"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getconnectioncount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getconnectioncount.md
@@ -17,10 +17,13 @@ The `getconnectioncount` RPC {{summary_getConnectionCount}}
 
 *Result---the number of connections to other nodes*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | number (int)    | Required<br>(exactly 1)     | The total number of connections to other nodes (both inbound and outbound)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of connections to other nodes (both inbound and outbound)"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getdifficulty.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getdifficulty.md
@@ -17,10 +17,13 @@ The `getdifficulty` RPC {{summary_getDifficulty}}
 
 *Result---the current difficulty*
 
-| Name             | Type              | Presence                    | Description
-|------------------|-------------------|-----------------------------|----------------
-| `result`         | number (real)     | Required<br>(exactly 1)     | The difficulty of creating a block with the same target threshold (nBits) as the highest-height block in the local best block chain.  The number is a a multiple of the minimum difficulty
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The difficulty of creating a block with the same target threshold (nBits) as the highest-height block in the local best block chain.  The number is a a multiple of the minimum difficulty"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getgenerate.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getgenerate.md
@@ -19,10 +19,13 @@ The `getgenerate` RPC {{summary_getGenerate}}
 
 *Result---whether the server is set to generate blocks*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | bool            | Required<br>(exactly 1)     | Set to `true` if the server is set to generate blocks; set to `false` if it is not
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the server is set to generate blocks; set to `false` if it is not"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/gethashespersec.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/gethashespersec.md
@@ -19,10 +19,13 @@ The `gethashespersec` RPC {{summary_getHashesPerSec}}
 
 *Result---the number of hashes your computer generated per second*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | number (int)    | Required<br>(exactly 1)     | If generation is enabled, the number of hashes per second your computer most recently generated.  If generation is disabled, the value `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "If generation is enabled, the number of hashes per second your computer most recently generated.  If generation is disabled, the value `0`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getinfo.md
@@ -20,26 +20,93 @@ Core.  Use the RPCs listed in the See Also subsection below instead.
 
 *Result---information about the node and network*
 
-| Name                   | Type              | Presence                    | Description
-|------------------------|-------------------|-----------------------------|----------------
-| `result`               | object            | Required<br>(exactly 1)     | Information about this node and the network
-| →<br>`version`         | number (int)      | Required<br>(exactly 1)     | This node's version of Bitcoin Core in its internal integer format.  For example, Bitcoin Core 0.9.2 has the integer version number 90200
-| →<br>`protocolversion` | number (int)      | Required<br>(exactly 1)     | The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information
-| →<br>`walletversion`   | number (int)      | Optional<br>(0 or 1)        | The version number of the wallet.  Only returned if wallet support is enabled
-| →<br>`balance`         | number (bitcoins) | Optional<br>(0 or 1)        | The balance of the wallet in bitcoins.  Only returned if wallet support is enabled
-| →<br>`blocks`          | number (int)      | Required<br>(exactly 1)     | The number of blocks in the local best block chain.  A new node with only the hardcoded genesis block will return `0`
-| →<br>`timeoffset`      | number (int)      | Required<br>(exactly 1)     | The offset of the node's clock from the computer's clock (both in UTC) in seconds.  The offset may be up to 4200 seconds (70 minutes)
-| →<br>`connections`     | number (int)      | Required<br>(exactly 1)     | The total number of open connections (both outgoing and incoming) between this node and other nodes
-| →<br>`proxy`           | string            | Required<br>(exactly 1)     | The hostname/IP address and port number of the proxy, if set, or an empty string if unset
-| →<br>`difficulty`      | number (real)     | Required<br>(exactly 1)     | The difficulty of the highest-height block in the local best block chain
-| →<br>`testnet`         | bool              | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if this node is on testnet; set to `false` if this node is on mainnet or a regtest
-| →<br>`keypoololdest`   | number (int)      | Optional<br>(0 or 1)        | The date as Unix epoch time when the oldest key in the wallet key pool was created; useful for only scanning blocks created since this date for transactions.  Only returned if wallet support is enabled
-| →<br>`keypoolsize`     | number (int)      | Optional<br>(0 or 1)        | The number of keys in the wallet keypool.  Only returned if wallet support is enabled
-| →<br>`paytxfee`        | number (bitcoins) | Optional<br>(0 or 1)        | The minimum fee to pay per kilobyte of transaction; may be `0`.  Only returned if wallet suuport is enabled
-| →<br>`relayfee`        | number (bitcoins) | Required<br>(exactly 1)     | The minimum fee a low-priority transaction must pay in order for this node to accept it into its memory pool
-| →<br>`unlocked_until`  | number (int)      | Optional<br>(0 or 1)        | The Unix epoch time when the wallet will automatically re-lock.  Only displayed if wallet encryption is enabled.  Set to `0` if wallet is currently locked
-| →<br>`errors`          | string            | Required<br>(exactly 1)     | A plain-text description of any errors this node has encountered or detected.  If there are no errors, an empty string will be returned.  This is not related to the JSON-RPC `error` field
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Information about this node and the network"
+
+- n: "→<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "This node's version of Bitcoin Core in its internal integer format.  For example, Bitcoin Core 0.9.2 has the integer version number 90200"
+
+- n: "→<br>`protocolversion`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information"
+
+- n: "→<br>`walletversion`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The version number of the wallet.  Only returned if wallet support is enabled"
+
+- n: "→<br>`balance`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "The balance of the wallet in bitcoins.  Only returned if wallet support is enabled"
+
+- n: "→<br>`blocks`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of blocks in the local best block chain.  A new node with only the hardcoded genesis block will return `0`"
+
+- n: "→<br>`timeoffset`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The offset of the node's clock from the computer's clock (both in UTC) in seconds.  The offset may be up to 4200 seconds (70 minutes)"
+
+- n: "→<br>`connections`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of open connections (both outgoing and incoming) between this node and other nodes"
+
+- n: "→<br>`proxy`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The hostname/IP address and port number of the proxy, if set, or an empty string if unset"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The difficulty of the highest-height block in the local best block chain"
+
+- n: "→<br>`testnet`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if this node is on testnet; set to `false` if this node is on mainnet or a regtest"
+
+- n: "→<br>`keypoololdest`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The date as Unix epoch time when the oldest key in the wallet key pool was created; useful for only scanning blocks created since this date for transactions.  Only returned if wallet support is enabled"
+
+- n: "→<br>`keypoolsize`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of keys in the wallet keypool.  Only returned if wallet support is enabled"
+
+- n: "→<br>`paytxfee`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "The minimum fee to pay per kilobyte of transaction; may be `0`.  Only returned if wallet suuport is enabled"
+
+- n: "→<br>`relayfee`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The minimum fee a low-priority transaction must pay in order for this node to accept it into its memory pool"
+
+- n: "→<br>`unlocked_until`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The Unix epoch time when the wallet will automatically re-lock.  Only displayed if wallet encryption is enabled.  Set to `0` if wallet is currently locked"
+
+- n: "→<br>`errors`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A plain-text description of any errors this node has encountered or detected.  If there are no errors, an empty string will be returned.  This is not related to the JSON-RPC `error` field"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0 with wallet support enabled*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getmempoolinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getmempoolinfo.md
@@ -19,12 +19,23 @@ The `getmempoolinfo` RPC {{summary_getMemPoolInfo}}
 
 *Result---information about the transaction memory pool*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | object          | Required<br>(exactly 1)     | A object containing information about the memory pool
-| →<br>`size`      | number (int)    | Required<br>(exactly 1)     | The number of transactions currently in the memory pool
-| →<br>`bytes`     | number (int)    | Required<br>(exactly 1)     | The total number of bytes in the transactions in the memory pool
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "A object containing information about the memory pool"
+
+- n: "→<br>`size`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of transactions currently in the memory pool"
+
+- n: "→<br>`bytes`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bytes in the transactions in the memory pool"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getmininginfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getmininginfo.md
@@ -17,22 +17,73 @@ The `getmininginfo` RPC {{summary_getMiningInfo}}
 
 *Result---various mining-related information*
 
-| Name                    | Type              | Presence                    | Description
-|-------------------------|-------------------|-----------------------------|----------------
-| `result`                | object            | Required<br>(exactly 1)     | Various mining-related information
-| →<br>`blocks`           | number (int)      | Required<br>(exactly 1)     | The height of the highest block on the local best block chain
-| →<br>`currentblocksize` | number (int)      | Required<br>(exactly 1)     | If generation was enabled since the last time this node was restarted, this is the size in bytes of the last block built by this node for header hash checking.  Otherwise, the value `0`
-| →<br>`currentblocktx`   | number (int)      | Required<br>(exactly 1)     | If generation was enabled since the last time this node was restarted, this is the number of transactions in the last block built by this node for header hash checking.  Otherwise, this is the value `0`
-| →<br>`difficulty`       | number (real)     | Required<br>(exactly 1)     | If generation was enabled since the last time this node was restarted, this is the difficulty of the highest-height block in the local best block chain.  Otherwise, this is the value `0`
-| →<br>`errors`           | string            | Required<br>(exactly 1)     | A plain-text description of any errors this node has encountered or detected.  If there are no errors, an empty string will be returned.  This is not related to the JSON-RPC `error` field
-| →<br>`genproclimit`     | number (int)      | Required<br>(exactly 1)     | The limit on the number of processors to use for generation.  If generation was enabled since the last time this node was restarted, this is the number used in the second parameter of the `setgenerate` RPC (or the default).  Otherwise, it is `-1`
-| →<br>`networkhashps`    | number (int)      | Required<br>(exactly 1)     | An estimate of the number of hashes per second the network is generating to maintain the current difficulty.  See the `getnetworkhashps` RPC for configurable access to this data
-| →<br>`pooledtx`         | number (int)      | Required<br>(exactly 1)     | The number of transactions in the memory pool
-| →<br>`testnet`          | bool              | Required<br>(exactly 1)     | Set to `true` if this node is running on testnet.  Set to `false` if this node is on mainnet or a regtest
-| →<br>`chain`            | string            | Required<br>(exactly 1)     | Set to `main` for mainnet, `test` for testnet, and `regtest` for regtest
-| →<br>`generate`         | bool              | Optional<br>(0 or 1)        | Set to `true` if generation is currently enabled; set to `false` if generation is currently disabled.  Only returned if the node has wallet support enabled
-| →<br>`hashespersec`     | number (int)      | Optional<br>(0 or 1)        | *Removed in Bitcoin Core master (unreleased)*<br><br>The approximate number of hashes per second this node is generating across all CPUs, if generation is enabled.  Otherwise `0`.  Only returned if the node has wallet support enabled
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Various mining-related information"
+
+- n: "→<br>`blocks`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of the highest block on the local best block chain"
+
+- n: "→<br>`currentblocksize`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "If generation was enabled since the last time this node was restarted, this is the size in bytes of the last block built by this node for header hash checking.  Otherwise, the value `0`"
+
+- n: "→<br>`currentblocktx`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "If generation was enabled since the last time this node was restarted, this is the number of transactions in the last block built by this node for header hash checking.  Otherwise, this is the value `0`"
+
+- n: "→<br>`difficulty`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "If generation was enabled since the last time this node was restarted, this is the difficulty of the highest-height block in the local best block chain.  Otherwise, this is the value `0`"
+
+- n: "→<br>`errors`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A plain-text description of any errors this node has encountered or detected.  If there are no errors, an empty string will be returned.  This is not related to the JSON-RPC `error` field"
+
+- n: "→<br>`genproclimit`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The limit on the number of processors to use for generation.  If generation was enabled since the last time this node was restarted, this is the number used in the second parameter of the `setgenerate` RPC (or the default).  Otherwise, it is `-1`"
+
+- n: "→<br>`networkhashps`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "An estimate of the number of hashes per second the network is generating to maintain the current difficulty.  See the `getnetworkhashps` RPC for configurable access to this data"
+
+- n: "→<br>`pooledtx`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of transactions in the memory pool"
+
+- n: "→<br>`testnet`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if this node is running on testnet.  Set to `false` if this node is on mainnet or a regtest"
+
+- n: "→<br>`chain`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `main` for mainnet, `test` for testnet, and `regtest` for regtest"
+
+- n: "→<br>`generate`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if generation is currently enabled; set to `false` if generation is currently disabled.  Only returned if the node has wallet support enabled"
+
+- n: "→<br>`hashespersec`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "*Removed in Bitcoin Core master (unreleased)*<br><br>The approximate number of hashes per second this node is generating across all CPUs, if generation is enabled.  Otherwise `0`.  Only returned if the node has wallet support enabled"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getnettotals.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getnettotals.md
@@ -17,13 +17,28 @@ The `getnettotals` RPC {{summary_getNetTotals}}
 
 *Result---the current bytes in, bytes out, and current time*
 
-| Name                  | Type            | Presence                    | Description
-|-----------------------|-----------------|-----------------------------|----------------
-| `result`              | object          | Required<br>(exactly 1)     | An object containing information about the node's network totals
-| →<br>`totalbytesrecv` | number (int)    | Required<br>(exactly 1)     | The total number of bytes received since the node was last restarted
-| →<br>`totalbytessent` | number (int)    | Required<br>(exactly 1)     | The total number of bytes sent since the node was last restarted
-| →<br>`timemillis`     | number (int)    | Required<br>(exactly 1)     | Unix epoch time in milliseconds according to the operating system's clock (not the node adjusted time)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing information about the node's network totals"
+
+- n: "→<br>`totalbytesrecv`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bytes received since the node was last restarted"
+
+- n: "→<br>`totalbytessent`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bytes sent since the node was last restarted"
+
+- n: "→<br>`timemillis`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "Unix epoch time in milliseconds according to the operating system's clock (not the node adjusted time)"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getnetworkhashps.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getnetworkhashps.md
@@ -15,24 +15,33 @@ The `getnetworkhashps` RPC {{summary_getNetworkHashPS}}
 
 *Parameter #1---number of blocks to average*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Blocks             | number (int)    | Optional<br>(0 or 1)        | The number of blocks to average together for calculating the estimated hashes per second.  Default is `120`.  Use `-1` to average all blocks produced since the last difficulty change
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Blocks"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of blocks to average together for calculating the estimated hashes per second.  Default is `120`.  Use `-1` to average all blocks produced since the last difficulty change"
+
+{% enditemplate %}
 
 *Parameter #2---block height*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Height             | number (int)    | Optional<br>(0 or 1)        | The height of the last block to use for calculating the average.  Defaults to `-1` for the highest-height block on the local best block chain.  If the specified height is higher than the highest block on the local best block chain, it will be interpreted the same as `-1`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Height"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The height of the last block to use for calculating the average.  Defaults to `-1` for the highest-height block on the local best block chain.  If the specified height is higher than the highest block on the local best block chain, it will be interpreted the same as `-1`"
+
+{% enditemplate %}
 
 *Result---estimated hashes per second*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | number (int)    | Required<br>(exactly 1)     | The estimated number of hashes per second based on the parameters provided.  May be 0 (for Height=`0`, the genesis block) or a negative value if the highest-height block averaged has a block header time earlier than the lowest-height block averaged
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The estimated number of hashes per second based on the parameters provided.  May be 0 (for Height=`0`, the genesis block) or a negative value if the highest-height block averaged has a block header time earlier than the lowest-height block averaged"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getnetworkinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getnetworkinfo.md
@@ -19,29 +19,108 @@ The `getnetworkinfo` RPC {{summary_getNetworkInfo}}
 
 *Result---information about the node's connection to the network*
 
-| Name                      | Type            | Presence                    | Description
-|---------------------------|-------------------|-----------------------------|----------------
-| `result`                  | object            | Required<br>(exactly 1)     | Information about this node's connection to the network
-| →<br>`version`            | number            | Required<br>(exactly 1)     | This node's version of Bitcoin Core in its internal integer format.  For example, Bitcoin Core 0.9.2 has the integer version number 90200
-| →<br>`subversion`         | string            | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>The user agent this node sends in its `version` message
-| →<br>`protocolversion`    | number (int)      | Required<br>(exactly 1)     | The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information
-| →<br>`timeoffset`         | number (int)      | Required<br>(exactly 1)     | The offset of the node's clock from the computer's clock (both in UTC) in seconds.  The offset may be up to 4200 seconds (70 minutes)
-| →<br>`connections`        | number (int)      | Required<br>(exactly 1)     | The total number of open connections (both outgoing and incoming) between this node and other nodes
-| →<br>`proxy`              | string            | Required<br>(exactly 1)     | The hostname/IP address and port number of the proxy, if set, or an empty string if unset
-| →<br>`relayfee`           | number (bitcoins) | Required<br>(exactly 1)     | The minimum fee a low-priority transaction must pay in order for this node to accept it into its memory pool
-| →<br>`localservices`      | string (hex)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>The services supported by this node as advertised in its `version` message
-| →<br>`networks`           | array             | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>An array with three objects: one describing the IPv4 connection, one describing the IPv6 connection, and one describing the Tor hidden service (onion) connection
-| → →<br>Network            | object            | Optional<br>(0 to 3)        | An object describing a network.  If the network is unroutable, it will not be returned
-| → → →<br>`name`           | string            | Required<br>(exactly 1)     | The name of the network.  Either `ipv4`, `ipv6`, or `onion`
-| → → →<br>`limited`        | bool              | Required<br>(exactly 1)     | Set to `true` if only connections to this network are allowed according to the `-onlynet` Bitcoin Core command-line/configuration-file parameter.  Otherwise set to `false`
-| → → →<br>`reachable`      | bool              | Required<br>(exactly 1)     | Set to `true` if connections can be made to or from this network.  Otherwise set to `false`
-| → → →<br>`proxy`          | string            | Required<br>(exactly 1)     | The hostname and port of any proxy being used for this network.  If a proxy is not in use, an empty string
-| → → →<br>`localaddresses` | array             | Required<br>(exactly 1)     | An array of objects each describing the local addresses this node believes it listens on
-| → → → →<br>Address       | object             | Optional<br>(0 or more)     | An object describing a particular address this node believes it listens on
-| → → → → →<br>`address`    | string            | Required<br>(exactly 1)     | An IP address or .onion address this node believes it listens on.  This may be manually configured, auto detected, or based on `version` messages this node received from its peers
-| → → → → →<br>`port`       | number (int)      | Required<br>(exactly 1)     | The port number this node believes it listens on for the associated `address`.  This may be manually configured, auto detected, or based on `version` messages this node received from its peers
-| → → → → →<br>`score`      | number (int)      | Required<br>(exactly 1)     | The self-assigned score this node gives to this connection; higher scores means the node thinks this connection is better <!-- SOMEDAY: figure out scores -->
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Information about this node's connection to the network"
+
+- n: "→<br>`version`"
+  t: "number"
+  p: "Required<br>(exactly 1)"
+  d: "This node's version of Bitcoin Core in its internal integer format.  For example, Bitcoin Core 0.9.2 has the integer version number 90200"
+
+- n: "→<br>`subversion`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The user agent this node sends in its `version` message"
+
+- n: "→<br>`protocolversion`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information"
+
+- n: "→<br>`timeoffset`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The offset of the node's clock from the computer's clock (both in UTC) in seconds.  The offset may be up to 4200 seconds (70 minutes)"
+
+- n: "→<br>`connections`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of open connections (both outgoing and incoming) between this node and other nodes"
+
+- n: "→<br>`proxy`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The hostname/IP address and port number of the proxy, if set, or an empty string if unset"
+
+- n: "→<br>`relayfee`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The minimum fee a low-priority transaction must pay in order for this node to accept it into its memory pool"
+
+- n: "→<br>`localservices`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The services supported by this node as advertised in its `version` message"
+
+- n: "→<br>`networks`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>An array with three objects: one describing the IPv4 connection, one describing the IPv6 connection, and one describing the Tor hidden service (onion) connection"
+
+- n: "→ →<br>Network"
+  t: "object"
+  p: "Optional<br>(0 to 3)"
+  d: "An object describing a network.  If the network is unroutable, it will not be returned"
+
+- n: "→ → →<br>`name`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the network.  Either `ipv4`, `ipv6`, or `onion`"
+
+- n: "→ → →<br>`limited`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if only connections to this network are allowed according to the `-onlynet` Bitcoin Core command-line/configuration-file parameter.  Otherwise set to `false`"
+
+- n: "→ → →<br>`reachable`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if connections can be made to or from this network.  Otherwise set to `false`"
+
+- n: "→ → →<br>`proxy`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The hostname and port of any proxy being used for this network.  If a proxy is not in use, an empty string"
+
+- n: "→ → →<br>`localaddresses`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects each describing the local addresses this node believes it listens on"
+
+- n: "→ → → →<br>Address"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object describing a particular address this node believes it listens on"
+
+- n: "→ → → → →<br>`address`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "An IP address or .onion address this node believes it listens on.  This may be manually configured, auto detected, or based on `version` messages this node received from its peers"
+
+- n: "→ → → → →<br>`port`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The port number this node believes it listens on for the associated `address`.  This may be manually configured, auto detected, or based on `version` messages this node received from its peers"
+
+- n: "→ → → → →<br>`score`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The self-assigned score this node gives to this connection; higher scores means the node thinks this connection is better <!-- SOMEDAY: figure out scores -->"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getnewaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getnewaddress.md
@@ -17,17 +17,23 @@ The `getnewaddress` RPC {{summary_getNewAddress}}
 
 *Parameter #1---an account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | The name of the account to put the address in.  The default is the default account, an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The name of the account to put the address in.  The default is the default account, an empty string (\"\")"
+
+{% enditemplate %}
 
 *Result---a bitcoin address never previously returned*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | A P2PKH address which has not previously been returned by this RPC.  The address will be marked as a receiving address in the wallet.  The address may already have been part of the keypool, so other RPCs such as the `dumpwallet` RPC may have disclosed it previously.  If the wallet is unlocked, its keypool will also be filled to its max (by default, 100 unused keys).  If the wallet is locked and its keypool is empty, this RPC will fail
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH address which has not previously been returned by this RPC.  The address will be marked as a receiving address in the wallet.  The address may already have been part of the keypool, so other RPCs such as the `dumpwallet` RPC may have disclosed it previously.  If the wallet is unlocked, its keypool will also be filled to its max (by default, 100 unused keys).  If the wallet is locked and its keypool is empty, this RPC will fail"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getpeerinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getpeerinfo.md
@@ -17,33 +17,128 @@ The `getpeerinfo` RPC {{summary_getPeerInfo}}
 
 *Result---information about each currently-connected network node*
 
-| Name                    | Type              | Presence                    | Description
-|-------------------------|-------------------|-----------------------------|----------------
-| `result`                | array             | Required<br>(exactly 1)     | An array of objects each describing one connected node.  If there are no connections, the array will be empty
-| →<br>Node               | object            | Optional<br>(0 or more)     | An object describing a particular connected node
-| → →<br>`id`             | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>The node's index number in the local node address database
-| → →<br>`addr`           | string            | Required<br>(exactly 1)     | The IP address and port number used for the connection to the remote node
-| → →<br>`addrlocal`      | string            | Optional<br>(0 or 1)        | Our IP address and port number according to the remote node.  May be incorrect due to error or lying.  Many SPV nodes set this to `127.0.0.1:8333`
-| → →<br>`services`       | string (hex)      | Required<br>(exactly 1)     | The services advertised by the remote node in its `version` message
-| → →<br>`lastsend`       | number (int)      | Required<br>(exactly 1)     | The Unix epoch time when we last successfully sent data to the TCP socket for this node
-| → →<br>`lastrecv`       | number (int)      | Required<br>(exactly 1)     | The Unix epoch time when we last received data from this node
-| → →<br>`bytessent`      | number (int)      | Required<br>(exactly 1)     | The total number of bytes we've sent to this node
-| → →<br>`bytesrecv`      | number (int)      | Required<br>(exactly 1)     | The total number of bytes we've received from this node
-| → →<br>`conntime`       | number (int)      | Required<br>(exactly 1)     | The Unix epoch time when we connected to this node
-| → →<br>`pingtime`       | number (real)     | Required<br>(exactly 1)     | The number of seconds this node took to respond to our last P2P `ping` message
-| → →<br>`pingwait`       | number (real)     | Optional<br>(0 or 1)        | The number of seconds we've been waiting for this node to respond to a P2P `ping` message.  Only shown if there's an outstanding `ping` message
-| → →<br>`version`        | number (int)      | Required<br>(exactly 1)     | The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information
-| → →<br>`subver`         | string            | Required<br>(exactly 1)     | The user agent this node sends in its `version` message.  This string will have been sanitized to prevent corrupting the JSON results.  May be an empty string
-| → →<br>`inbound`        | bool              | Required<br>(exactly 1)     | Set to `true` if this node connected to us; set to `false` if we connected to this node
-| → →<br>`startingheight` | number (int)      | Required<br>(exactly 1)     | The height of the remote node's block chain when it connected to us as reported in its `version` message
-| → →<br>`banscore`       | number (int)      | Required<br>(exactly 1)     | The ban score we've assigned the node based on any misbehavior it's made.  By default, Bitcoin Core disconnects when the ban score reaches `100`
-| → →<br>`synced_headers` | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>The highest-height header we have in common with this node based the last P2P `headers` message it sent us.  If a `headers` message has not been received, this will be set to `-1`
-| → →<br>`synced_blocks`  | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>The highest-height block we have in common with this node based on P2P `inv` messages this node sent us.  If no block `inv` messages have been received from this node, this will be set to `-1`
-| → →<br>`syncnode`       | bool              | Required<br>(exactly 1)     | *Removed in Bitcoin Core 0.10.0*<br><br>Whether we're using this node as our syncnode during initial block download
-| → →<br>`inflight`       | array             | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>An array of blocks which have been requested from this peer.  May be empty
-| → → →<br>Blocks         | number (int)      | Optional<br>(0 or more)     | The height of a block being requested from the remote peer
-| → →<br>`whitelisted`    | bool              | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the remote peer has been whitelisted; otherwise, set to `false`.  Whitelisted peers will not be banned if their ban score exceeds the maximum (100 by default).  By default, peers connecting from localhost are whitelisted
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects each describing one connected node.  If there are no connections, the array will be empty"
+
+- n: "→<br>Node"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object describing a particular connected node"
+
+- n: "→ →<br>`id`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The node's index number in the local node address database"
+
+- n: "→ →<br>`addr`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The IP address and port number used for the connection to the remote node"
+
+- n: "→ →<br>`addrlocal`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "Our IP address and port number according to the remote node.  May be incorrect due to error or lying.  Many SPV nodes set this to `127.0.0.1:8333`"
+
+- n: "→ →<br>`services`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The services advertised by the remote node in its `version` message"
+
+- n: "→ →<br>`lastsend`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The Unix epoch time when we last successfully sent data to the TCP socket for this node"
+
+- n: "→ →<br>`lastrecv`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The Unix epoch time when we last received data from this node"
+
+- n: "→ →<br>`bytessent`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bytes we've sent to this node"
+
+- n: "→ →<br>`bytesrecv`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bytes we've received from this node"
+
+- n: "→ →<br>`conntime`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The Unix epoch time when we connected to this node"
+
+- n: "→ →<br>`pingtime`"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of seconds this node took to respond to our last P2P `ping` message"
+
+- n: "→ →<br>`pingwait`"
+  t: "number (real)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of seconds we've been waiting for this node to respond to a P2P `ping` message.  Only shown if there's an outstanding `ping` message"
+
+- n: "→ →<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The protocol version number used by this node.  See the [protocol versions section][section protocol versions] for more information"
+
+- n: "→ →<br>`subver`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The user agent this node sends in its `version` message.  This string will have been sanitized to prevent corrupting the JSON results.  May be an empty string"
+
+- n: "→ →<br>`inbound`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if this node connected to us; set to `false` if we connected to this node"
+
+- n: "→ →<br>`startingheight`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of the remote node's block chain when it connected to us as reported in its `version` message"
+
+- n: "→ →<br>`banscore`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The ban score we've assigned the node based on any misbehavior it's made.  By default, Bitcoin Core disconnects when the ban score reaches `100`"
+
+- n: "→ →<br>`synced_headers`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The highest-height header we have in common with this node based the last P2P `headers` message it sent us.  If a `headers` message has not been received, this will be set to `-1`"
+
+- n: "→ →<br>`synced_blocks`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>The highest-height block we have in common with this node based on P2P `inv` messages this node sent us.  If no block `inv` messages have been received from this node, this will be set to `-1`"
+
+- n: "→ →<br>`syncnode`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "*Removed in Bitcoin Core 0.10.0*<br><br>Whether we're using this node as our syncnode during initial block download"
+
+- n: "→ →<br>`inflight`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>An array of blocks which have been requested from this peer.  May be empty"
+
+- n: "→ → →<br>Blocks"
+  t: "number (int)"
+  p: "Optional<br>(0 or more)"
+  d: "The height of a block being requested from the remote peer"
+
+- n: "→ →<br>`whitelisted`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the remote peer has been whitelisted; otherwise, set to `false`.  Whitelisted peers will not be banned if their ban score exceeds the maximum (100 by default).  By default, peers connecting from localhost are whitelisted"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getrawchangeaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getrawchangeaddress.md
@@ -19,10 +19,13 @@ The `getrawchangeaddress` RPC {{summary_getRawChangeAddress}}
 
 *Result---a P2PKH address which can be used in raw transactions*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | A P2PKH address which has not previously been returned by this RPC.  The address will be removed from the keypool but not marked as a receiving address, so RPCs such as the `dumpwallet` RPC will show it as a change address.  The address may already have been part of the keypool, so other RPCs such as the `dumpwallet` RPC may have disclosed it previously.  If the wallet is unlocked, its keypool will also be filled to its max (by default, 100 unused keys).  If the wallet is locked and its keypool is empty, this RPC will fail
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH address which has not previously been returned by this RPC.  The address will be removed from the keypool but not marked as a receiving address, so RPCs such as the `dumpwallet` RPC will show it as a change address.  The address may already have been part of the keypool, so other RPCs such as the `dumpwallet` RPC may have disclosed it previously.  If the wallet is unlocked, its keypool will also be filled to its max (by default, 100 unused keys).  If the wallet is locked and its keypool is empty, this RPC will fail"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getrawmempool.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getrawmempool.md
@@ -15,34 +15,83 @@ The `getrawmempool` RPC {{summary_getRawMemPool}}
 
 *Parameter---desired output format*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Format           | bool            | Optional<br>(0 or 1)        | Set to `true` to get verbose output describing each transaction in the memory pool; set to `false` (the default) to only get an array of TXIDs for transactions in the memory pool
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Format"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` to get verbose output describing each transaction in the memory pool; set to `false` (the default) to only get an array of TXIDs for transactions in the memory pool"
+
+{% enditemplate %}
 
 *Result (format `false`)---an array of TXIDs*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | array           | Required<br>(exactly 1)     | An array of TXIDs belonging to transactions in the memory pool.  The array may be empty if there are no transactions in the memory pool
-| →<br>TXID        | string          | Optional<br>(0 or more)     | The TXID of a transaction in the memory pool, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of TXIDs belonging to transactions in the memory pool.  The array may be empty if there are no transactions in the memory pool"
+
+- n: "→<br>TXID"
+  t: "string"
+  p: "Optional<br>(0 or more)"
+  d: "The TXID of a transaction in the memory pool, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Result (format: `true`)---a JSON object describing each transaction*
 
-| Name                      | Type              | Presence                    | Description
-|---------------------------|-------------------|-----------------------------|----------------
-| `result`                  | object            | Required<br>(exactly 1)     | A object containing transactions currently in the memory pool.  May be empty
-| →<br>TXID                 | string : object   | Optional<br>(0 or more)     | The TXID of a transaction in the memory pool, encoded as hex in RPC byte order
-| → →<br>`size`             | number (int)      | Required<br>(exactly 1)     | The size of the serialized transaction in bytes
-| → →<br>`fee`              | number (bitcoins) | Required<br>(exactly 1)     | The transaction fee paid by the transaction in decimal bitcoins
-| → →<br>`time`             | number (int)      | Required<br>(exactly 1)     | The time the transaction entered the memory pool, Unix epoch time format
-| → →<br>`height`           | number (int)      | Required<br>(exactly 1)     | The block height when the transaction entered the memory pool
-| → →<br>`startingpriority` | number (int)      | Required<br>(exactly 1)     | The priority of the transaction when it first entered the memory pool
-| → →<br>`currentpriority`  | number (int)      | Required<br>(exactly 1)     | The current priority of the transaction
-| → →<br>`depends`          | array             | Required<br>(exactly 1)     | An array holding TXIDs of unconfirmed transactions this transaction depends upon.  Those transactions must be part of a block before this transaction can be added to a block, although all transactions may be included in the same block.  The array may be empty
-| → → →<br>Depends TXID     | string            | Optional (0 or more)        | The TXIDs of any unconfirmed transactions this transaction depends upon, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "A object containing transactions currently in the memory pool.  May be empty"
+
+- n: "→<br>TXID"
+  t: "string : object"
+  p: "Optional<br>(0 or more)"
+  d: "The TXID of a transaction in the memory pool, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`size`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The size of the serialized transaction in bytes"
+
+- n: "→ →<br>`fee`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction fee paid by the transaction in decimal bitcoins"
+
+- n: "→ →<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The time the transaction entered the memory pool, Unix epoch time format"
+
+- n: "→ →<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The block height when the transaction entered the memory pool"
+
+- n: "→ →<br>`startingpriority`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The priority of the transaction when it first entered the memory pool"
+
+- n: "→ →<br>`currentpriority`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The current priority of the transaction"
+
+- n: "→ →<br>`depends`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array holding TXIDs of unconfirmed transactions this transaction depends upon.  Those transactions must be part of a block before this transaction can be added to a block, although all transactions may be included in the same block.  The array may be empty"
+
+- n: "→ → →<br>Depends TXID"
+  t: "string"
+  p: "Optional (0 or more)"
+  d: "The TXIDs of any unconfirmed transactions this transaction depends upon, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getrawtransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getrawtransaction.md
@@ -17,43 +17,74 @@ The `getrawtransaction` RPC {{summary_getRawTransaction}}
 
 *Parameter #1---the TXID of the transaction to get*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| TXID               | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "TXID"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---whether to get the serialized or decoded transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Verbose            | number (int)    | Optional<br>(0 or 1)        | Set to `0` (the default) to return the serialized transaction as hex.  Set to `1` to return a decoded transaction
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Verbose"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `0` (the default) to return the serialized transaction as hex.  Set to `1` to return a decoded transaction"
+
+{% enditemplate %}
 
 *Result (if transaction not found)---`null`*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | If the transaction wasn't found, the result will be JSON `null`.  This can occur because the transaction doesn't exist in the block chain or memory pool, or because it isn't part of the transaction index.  See the Bitcoin Core `-help` entry for `-txindex`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction wasn't found, the result will be JSON `null`.  This can occur because the transaction doesn't exist in the block chain or memory pool, or because it isn't part of the transaction index.  See the Bitcoin Core `-help` entry for `-txindex`"
+
+{% enditemplate %}
 
 *Result (if verbose=`0`)---the serialized transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (hex)    | Required<br>(exactly 1)     | If the transaction was found, this will be the serialized transaction encoded as hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction was found, this will be the serialized transaction encoded as hex"
+
+{% enditemplate %}
 
 *Result (if verbose=`1`)---the decoded transaction*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| `result`             | object          | Required<br>(exactly 1)     | If the transaction was found, this will be an object describing it
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction was found, this will be an object describing it"
+
 {{INCLUDE_DECODE_RAW_TRANSACTION}}
-| →<br>`blockhash`     | string (hex)    | Optional<br>(0 or 1)        | If the transaction has been included in a block on the local best block chain, this is the hash of that block encoded as hex in RPC byte order
-| →<br>`confirmations` | number (int)    | Required<br>(exactly 1)     | If the transaction has been included in a block on the local best block chain, this is how many confirmations it has.  Otherwise, this is `0`
-| →<br>`time`          | number (int)    | Optional<br>(0 or 1)        | If the transaction has been included in a block on the local best block chain, this is the block header time of that block (may be in the future)
-| →<br>`blocktime`     | number (int)    | Optional<br>(0 or 1)        | This field is currently identical to the time field described above
-{:.ntpd}
+- n: "→<br>`blockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is the hash of that block encoded as hex in RPC byte order"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is how many confirmations it has.  Otherwise, this is `0`"
+
+- n: "→<br>`time`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the transaction has been included in a block on the local best block chain, this is the block header time of that block (may be in the future)"
+
+- n: "→<br>`blocktime`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "This field is currently identical to the time field described above"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getreceivedbyaccount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getreceivedbyaccount.md
@@ -17,10 +17,13 @@ The `getreceivedbyaccount` RPC {{summary_getReceivedByAccount}}
 
 *Parameter #1---the account name*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Required<br>(exactly 1)     | The name of the account containing the addresses to get.  For the default account, use an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account containing the addresses to get.  For the default account, use an empty string (\"\")"
+
+{% enditemplate %}
 
 *Parameter #2---the minimum number of confirmations*
 
@@ -28,10 +31,13 @@ The `getreceivedbyaccount` RPC {{summary_getReceivedByAccount}}
 
 *Result---the number of bitcoins received*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (bitcoins) | Required<br>(exactly 1)     | The number of bitcoins received by the account.  May be `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of bitcoins received by the account.  May be `0`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getreceivedbyaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getreceivedbyaddress.md
@@ -17,10 +17,13 @@ The `getreceivedbyaddress` RPC {{summary_getReceivedByAddress}}
 
 *Parameter #1---the address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Address            | string          | Required<br>(exactly 1)     | The address whose transactions should be tallied
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The address whose transactions should be tallied"
+
+{% enditemplate %}
 
 *Parameter #2---the minimum number of confirmations*
 
@@ -28,10 +31,13 @@ The `getreceivedbyaddress` RPC {{summary_getReceivedByAddress}}
 
 *Result---the number of bitcoins received*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (bitcoins) | Required<br>(exactly 1)     | The number of bitcoins received by the address, excluding coinbase transactions.  May be `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of bitcoins received by the address, excluding coinbase transactions.  May be `0`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/gettransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/gettransaction.md
@@ -17,10 +17,13 @@ The `gettransaction` RPC {{summary_getTransaction}}
 
 *Parameter #1---a transaction identifier (TXID)*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| TXID               | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction to get details about.  The TXID must be encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "TXID"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction to get details about.  The TXID must be encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---whether to include watch-only addresses in details and calculations*
 
@@ -31,22 +34,69 @@ The `gettransaction` RPC {{summary_getTransaction}}
 {% assign DEPTH="→ " %}
 {% include helpers/vars.md %}
 
-| Name                        | Type              | Presence                    | Description
-|-----------------------------|-------------------|-----------------------------|----------------
-| `result`                    | object            | Required<br>(exactly 1)     | An object describing how the transaction affects the wallet
-| →<br>`amount`               | number (bitcoins) | Required<br>(exactly 1)     | A positive number of bitcoins if this transaction increased the total wallet balance; a negative number of bitcoins if this transaction decreased the total wallet balance, or `0` if the transaction had no net effect on wallet balance
-| →<br>`fee`                  | number (bitcoins) | Optional<br>(0 or 1)        | If an outgoing transaction, this is the fee paid by the transaction reported as negative bitcoins
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing how the transaction affects the wallet"
+
+- n: "→<br>`amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "A positive number of bitcoins if this transaction increased the total wallet balance; a negative number of bitcoins if this transaction decreased the total wallet balance, or `0` if the transaction had no net effect on wallet balance"
+
+- n: "→<br>`fee`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "If an outgoing transaction, this is the fee paid by the transaction reported as negative bitcoins"
+
 {{INCLUDE_F_LIST_TRANSACTIONS_F_FULL}}
-| →<br>`details`              | array             | Required<br>(exactly 1)     | An array containing one object for each input or output in the transaction which affected the wallet
-| → → <br>`involvesWatchonly` | bool              | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the input or output involves a watch-only address.  Otherwise not returned
-| → →<br>`account`            | string            | Required<br>(exactly 1)     | The account which the payment was credited to or debited from.  May be an empty string ("") for the default account
-| → →<br>`address`            | string (base58)   | Optional<br>(0 or 1)        | If an output, the address paid (may be someone else's address not belonging to this wallet).  If an input, the address paid in the previous output.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script
-| → →<br>`category`           | string            | Required<br>(exactly 1)     | Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain
-| → →<br>`amount`             | number (bitcoins) | Required<br>(exactly 1)     | A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)
-| → →<br>`vout`               | number (int)      | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index
-| → →<br>`fee`                | number (bitcoins) | Optional<br>(0 or 1)        | If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment
-| →<br>`hex`                  | string (hex)      | Required<br>(exactly 1)     | The transaction in serialized transaction format
-{:.ntpd}
+- n: "→<br>`details`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing one object for each input or output in the transaction which affected the wallet"
+
+- n: "→ → <br>`involvesWatchonly`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the input or output involves a watch-only address.  Otherwise not returned"
+
+- n: "→ →<br>`account`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The account which the payment was credited to or debited from.  May be an empty string (\"\") for the default account"
+
+- n: "→ →<br>`address`"
+  t: "string (base58)"
+  p: "Optional<br>(0 or 1)"
+  d: "If an output, the address paid (may be someone else's address not belonging to this wallet).  If an input, the address paid in the previous output.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script"
+
+- n: "→ →<br>`category`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain"
+
+- n: "→ →<br>`amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index"
+
+- n: "→ →<br>`fee`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment"
+
+- n: "→<br>`hex`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction in serialized transaction format"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/gettxout.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/gettxout.md
@@ -15,44 +15,104 @@ The `gettxout` RPC {{summary_getTxOut}}
 
 *Parameter #1---the TXID of the output to get*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| TXID             | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction containing the output to get, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "TXID"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction containing the output to get, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 
 *Parameter #2---the output index number (vout) of the output to get*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Vout             | number (int)    | Required<br>(exactly 1)     | The output index number (vout) of the output within the transaction; the first output in a transaction is vout 0
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Vout"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number (vout) of the output within the transaction; the first output in a transaction is vout 0"
+
+{% enditemplate %}
 
 *Parameter #3---whether to display unconfirmed outputs from the memory pool*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Unconfirmed      | bool            | Optional<br>(0 or 1)        | Set to `true` to display unconfirmed outputs from the memory pool; set to `false` (the default) to only display outputs from confirmed transactions
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Unconfirmed"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` to display unconfirmed outputs from the memory pool; set to `false` (the default) to only display outputs from confirmed transactions"
+
+{% enditemplate %}
 
 *Result---a description of the output*
 
-| Name                 | Type              | Presence                    | Description
-|----------------------|-------------------|-----------------------------|----------------
-| `result`             | object/null       | Required<br>(exactly 1)     | Information about the output.  If output wasn't found or if an error occurred, this will be JSON `null`
-| →<br>`bestblock`     | string (hex)      | Required<br>(exactly 1)     | The hash of the header of the block on the local best block chain which includes this transaction.  The hash will encoded as hex in RPC byte order.  If the transaction is not part of a block, the string will be empty
-| →<br>`confirmations` | number (int)      | Required<br>(exactly 1)     | The number of confirmations received for the transaction containing this output or `0` if the transaction hasn't been confirmed yet
-| →<br>`value`         | number (bitcoins) | Required<br>(exactly 1)     | The amount of bitcoins spent to this output.  May be `0`
-| →<br>`scriptPubKey`  | string : object   | Optional<br>(0 or 1)        | An object with information about the pubkey script.  This may be `null` if there was no pubkey script
-| → →<br>`asm`         | string            | Required<br>(exactly 1)     | The pubkey script in decoded form with non-data-pushing op codes listed
-| → →<br>`hex`         | string (hex)      | Required<br>(exactly 1)     | The pubkey script encoded as hex
-| → →<br>`reqSigs`     | number (int)      | Optional<br>(0 or 1)        | The number of signatures required; this is always `1` for P2PK, P2PKH, and P2SH (including P2SH multisig because the redeem script is not available in the pubkey script).  It may be greater than 1 for bare multisig.  This value will not be returned for `nulldata` or `nonstandard` script types (see the `type` key below)
-| → →<br>`type`        | string            | Optional<br>(0 or 1)        | The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script<br>• `pubkeyhash` for a P2PKH script<br>• `scripthash` for a P2SH script<br>• `multisig` for a bare multisig script<br>• `nulldata` for nulldata scripts<br>• `nonstandard` for unknown scripts
-| → →<br>`addresses`   | string : array    | Optional<br>(0 or 1)        | The P2PKH or P2SH addresses used in this transaction, or the computed P2PKH address of any pubkeys in this transaction.  This array will not be returned for `nulldata` or `nonstandard` script types
-| → → →<br>Address     | string            | Required<br>(1 or more)     | A P2PKH or P2SH address
-| →<br>`version`       | number (int)      | Required<br>(exactly 1)     | The transaction version number of the transaction containing the pubkey script
-| →<br>`coinbase`      | bool              | Required<br>(exactly 1)     | Set to `true` if the transaction output belonged to a coinbase transaction; set to `false` for all other transactions.  Coinbase transactions need to have 101 confirmations before their outputs can be spent
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object/null"
+  p: "Required<br>(exactly 1)"
+  d: "Information about the output.  If output wasn't found or if an error occurred, this will be JSON `null`"
+
+- n: "→<br>`bestblock`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the block on the local best block chain which includes this transaction.  The hash will encoded as hex in RPC byte order.  If the transaction is not part of a block, the string will be empty"
+
+- n: "→<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations received for the transaction containing this output or `0` if the transaction hasn't been confirmed yet"
+
+- n: "→<br>`value`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The amount of bitcoins spent to this output.  May be `0`"
+
+- n: "→<br>`scriptPubKey`"
+  t: "string : object"
+  p: "Optional<br>(0 or 1)"
+  d: "An object with information about the pubkey script.  This may be `null` if there was no pubkey script"
+
+- n: "→ →<br>`asm`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The pubkey script in decoded form with non-data-pushing op codes listed"
+
+- n: "→ →<br>`hex`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The pubkey script encoded as hex"
+
+- n: "→ →<br>`reqSigs`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of signatures required; this is always `1` for P2PK, P2PKH, and P2SH (including P2SH multisig because the redeem script is not available in the pubkey script).  It may be greater than 1 for bare multisig.  This value will not be returned for `nulldata` or `nonstandard` script types (see the `type` key below)"
+
+- n: "→ →<br>`type`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The type of script.  This will be one of the following:<br>• `pubkey` for a P2PK script<br>• `pubkeyhash` for a P2PKH script<br>• `scripthash` for a P2SH script<br>• `multisig` for a bare multisig script<br>• `nulldata` for nulldata scripts<br>• `nonstandard` for unknown scripts"
+
+- n: "→ →<br>`addresses`"
+  t: "string : array"
+  p: "Optional<br>(0 or 1)"
+  d: "The P2PKH or P2SH addresses used in this transaction, or the computed P2PKH address of any pubkeys in this transaction.  This array will not be returned for `nulldata` or `nonstandard` script types"
+
+- n: "→ → →<br>Address"
+  t: "string"
+  p: "Required<br>(1 or more)"
+  d: "A P2PKH or P2SH address"
+
+- n: "→<br>`version`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction version number of the transaction containing the pubkey script"
+
+- n: "→<br>`coinbase`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the transaction output belonged to a coinbase transaction; set to `false` for all other transactions.  Coinbase transactions need to have 101 confirmations before their outputs can be spent"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/gettxoutsetinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/gettxoutsetinfo.md
@@ -17,17 +17,48 @@ The `gettxoutsetinfo` RPC {{summary_getTxOutSetInfo}}
 
 *Result---statistics about the UTXO set*
 
-| Name                    | Type              | Presence                    | Description
-|-------------------------|-------------------|-----------------------------|----------------
-| `result`                | object            | Required<br>(exactly 1)     | Information about the UTXO set
-| →<br>`height`           | number (int)      | Required<br>(exactly 1)     | The height of the local best block chain.  A new node with only the hardcoded genesis block will have a height of 0
-| →<br>`bestblock`        | string (hex)      | Required<br>(exactly 1)     | The hash of the header of the highest block on the local best block chain, encoded as hex in RPC byte order
-| →<br>`transactions`     | number (int)      | Required<br>(exactly 1)     | The number of transactions with unspent outputs
-| →<br>`txouts`           | number (int)      | Required<br>(exactly 1)     | The number of unspent transaction outputs
-| →<br>`bytes_serialized` | number (int)      | Required<br>(exactly 1)     | The size of the serialized UTXO set in bytes; not counting overhead, this is the size of the `chainstate` directory in the Bitcoin Core configuration directory
-| →<br>`hash_serialized`  | string (hex)      | Required<br>(exactly 1)     | A SHA256(SHA256()) hash of the serialized UTXO set; useful for comparing two nodes to see if they have the same set (they should, if they always used the same serialization format and currently have the same best block).  The hash is encoded as hex in RPC byte order
-| →<br>`total_amount`     | number (bitcoins) | Required<br>(exactly 1)     | The total number of bitcoins in the UTXO set
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Information about the UTXO set"
+
+- n: "→<br>`height`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The height of the local best block chain.  A new node with only the hardcoded genesis block will have a height of 0"
+
+- n: "→<br>`bestblock`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The hash of the header of the highest block on the local best block chain, encoded as hex in RPC byte order"
+
+- n: "→<br>`transactions`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of transactions with unspent outputs"
+
+- n: "→<br>`txouts`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of unspent transaction outputs"
+
+- n: "→<br>`bytes_serialized`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The size of the serialized UTXO set in bytes; not counting overhead, this is the size of the `chainstate` directory in the Bitcoin Core configuration directory"
+
+- n: "→<br>`hash_serialized`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "A SHA256(SHA256()) hash of the serialized UTXO set; useful for comparing two nodes to see if they have the same set (they should, if they always used the same serialization format and currently have the same best block).  The hash is encoded as hex in RPC byte order"
+
+- n: "→<br>`total_amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bitcoins in the UTXO set"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getunconfirmedbalance.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getunconfirmedbalance.md
@@ -19,10 +19,13 @@ The `getunconfirmedbalance` RPC {{summary_getUnconfirmedBalance}}
 
 *Result---the balance of unconfirmed transactions paying this wallet*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | number (bitcoins) | Required<br>(exactly 1)     | The total number of bitcoins paid to this wallet in unconfirmed transactions
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of bitcoins paid to this wallet in unconfirmed transactions"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getwalletinfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getwalletinfo.md
@@ -19,16 +19,43 @@ The `getwalletinfo` RPC {{summary_getWalletInfo}}
 
 *Result---information about the wallet*
 
-| Name                  | Type              | Presence                    | Description
-|-----------------------|-------------------|-----------------------------|----------------
-| `result`              | object            | Required<br>(exactly 1)     | An object describing the wallet
-| →<br>`walletversion`  | number (int)      | Required<br>(exactly 1)     | The version number of the wallet
-| →<br>`balance`        | number (bitcoins) | Required<br>(exactly 1)     | The balance of the wallet.  The same as returned by the `getbalance` RPC with default parameters
-| →<br>`txcount`        | number (int)      | Required<br>(exactly 1)     | The total number of transactions in the wallet (both spends and receives)
-| →<br>`keypoololdest`  | number (int)      | Required<br>(exactly 1)     | The date as Unix epoch time when the oldest key in the wallet key pool was created; useful for only scanning blocks created since this date for transactions
-| →<br>`keypoolsize`    | number (int)      | Required<br>(exactly 1)     | The number of keys in the wallet keypool
-| →<br>`unlocked_until` | number (int)      | Optional<br>(0 or 1)        | Only returned if the wallet was encrypted with the `encryptwallet` RPC. A Unix epoch date when the wallet will be locked, or `0` if the wallet is currently locked
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object describing the wallet"
+
+- n: "→<br>`walletversion`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The version number of the wallet"
+
+- n: "→<br>`balance`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The balance of the wallet.  The same as returned by the `getbalance` RPC with default parameters"
+
+- n: "→<br>`txcount`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The total number of transactions in the wallet (both spends and receives)"
+
+- n: "→<br>`keypoololdest`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The date as Unix epoch time when the oldest key in the wallet key pool was created; useful for only scanning blocks created since this date for transactions"
+
+- n: "→<br>`keypoolsize`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of keys in the wallet keypool"
+
+- n: "→<br>`unlocked_until`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned if the wallet was encrypted with the `encryptwallet` RPC. A Unix epoch date when the wallet will be locked, or `0` if the wallet is currently locked"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/help.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/help.md
@@ -15,17 +15,23 @@ The `help` RPC {{summary_help}}
 
 *Parameter---the name of the RPC to get help for*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| RPC                | string          | Optional<br>(0 or 1)        | The name of the RPC to get help for.  If omitted, Bitcoin Core 0.9x will display an alphabetical list of commands; Bitcoin Core 0.10.0 will display a categorized list of commands
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "RPC"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The name of the RPC to get help for.  If omitted, Bitcoin Core 0.9x will display an alphabetical list of commands; Bitcoin Core 0.10.0 will display a categorized list of commands"
+
+{% enditemplate %}
 
 *Result---a list of RPCs or detailed help for a specific RPC*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string          | Required<br>(exactly 1)     | The help text for the specified RPC or the list of commands.  The `bitcoin-cli` command will parse this text and format it as human-readable text
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The help text for the specified RPC or the list of commands.  The `bitcoin-cli` command will parse this text and format it as human-readable text"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/importaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/importaddress.md
@@ -17,31 +17,43 @@ The `importaddress` RPC {{summary_importAddress}}
 
 *Parameter #1---the address or pubkey script to watch*
 
-| Name               | Type                   | Presence                    | Description
-|--------------------|------------------------|-----------------------------|----------------
-| Address or Script  | string (base58 or hex) | Required<br>(exactly 1)     | Either a P2PKH or P2SH address encoded in base58check, or a pubkey script encoded as hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address or Script"
+  t: "string (base58 or hex)"
+  p: "Required<br>(exactly 1)"
+  d: "Either a P2PKH or P2SH address encoded in base58check, or a pubkey script encoded as hex"
+
+{% enditemplate %}
 
 *Parameter #2---The account into which to place the address or pubkey script*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | An account name into which the address should be placed.  Default is the default account, an empty string("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "An account name into which the address should be placed.  Default is the default account, an empty string(\"\")"
+
+{% enditemplate %}
 
 *Parameter #3---whether to rescan the block chain*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Rescan             | bool            | Optional<br>(0 or 1)        | Set to `true` (the default) to rescan the entire local block database for transactions affecting any address or pubkey script in the wallet (including transaction affecting the newly-added address or pubkey script).  Set to `false` to not rescan the block database (rescanning can be performed at any time by restarting Bitcoin Core with the `-rescan` command-line argument).  Rescanning may take several minutes.  Notes: if the address or pubkey script is already in the wallet, the block database will not be rescanned even if this parameter is set
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Rescan"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` (the default) to rescan the entire local block database for transactions affecting any address or pubkey script in the wallet (including transaction affecting the newly-added address or pubkey script).  Set to `false` to not rescan the block database (rescanning can be performed at any time by restarting Bitcoin Core with the `-rescan` command-line argument).  Rescanning may take several minutes.  Notes: if the address or pubkey script is already in the wallet, the block database will not be rescanned even if this parameter is set"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | If the address or pubkey script is added to the wallet (or is already part of the wallet), JSON `null` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "If the address or pubkey script is added to the wallet (or is already part of the wallet), JSON `null` will be returned"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/importprivkey.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/importprivkey.md
@@ -17,31 +17,43 @@ The `importprivkey` RPC {{summary_importPrivKey}}
 
 *Parameter #1---the private key to import*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Private Key        | string (base58) | Required<br>(exactly 1)     | The private key to import into the wallet encoded in base58check using wallet import format (WIF)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Private Key"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The private key to import into the wallet encoded in base58check using wallet import format (WIF)"
+
+{% enditemplate %}
 
 *Parameter #2---the account into which the key should be placed*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Account            | string          | Optional<br>(0 or 1)        | The name of an account to which transactions involving the key should be assigned.  The default is the default account, an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The name of an account to which transactions involving the key should be assigned.  The default is the default account, an empty string (\"\")"
+
+{% enditemplate %}
 
 *Parameter #3---whether to rescan the block chain*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Rescan             | bool            | Optional<br>(0 or 1)        | Set to `true` (the default) to rescan the entire local block database for transactions affecting any address or pubkey script in the wallet (including transaction affecting the newly-added address for this private key).  Set to `false` to not rescan the block database (rescanning can be performed at any time by restarting Bitcoin Core with the `-rescan` command-line argument).  Rescanning may take several minutes.  Notes: if the address for this key is already in the wallet, the block database will not be rescanned even if this parameter is set
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Rescan"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` (the default) to rescan the entire local block database for transactions affecting any address or pubkey script in the wallet (including transaction affecting the newly-added address for this private key).  Set to `false` to not rescan the block database (rescanning can be performed at any time by restarting Bitcoin Core with the `-rescan` command-line argument).  Rescanning may take several minutes.  Notes: if the address for this key is already in the wallet, the block database will not be rescanned even if this parameter is set"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | If the private key is added to the wallet (or is already part of the wallet), JSON `null` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "If the private key is added to the wallet (or is already part of the wallet), JSON `null` will be returned"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/importwallet.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/importwallet.md
@@ -18,17 +18,23 @@ The `importwallet` RPC {{summary_importWallet}}
 
 *Parameter #1---the file to import*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Filename           | string          | Required<br>(exactly 1)     | The file to import.  The path is relative to Bitcoin Core's working directory
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Filename"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The file to import.  The path is relative to Bitcoin Core's working directory"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | If all the keys in the file are added to the wallet (or are already part of the wallet), JSON `null` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "If all the keys in the file are added to the wallet (or are already part of the wallet), JSON `null` will be returned"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/keypoolrefill.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/keypoolrefill.md
@@ -18,17 +18,23 @@ The `keypoolrefill` RPC {{summary_keyPoolRefill}}
 
 *Parameter #1---the new keypool size*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Key Pool Size      | number (int)    | Optional<br>(0 or 1)        | The new size of the keypool; if the number of keys in the keypool is less than this number, new keys will be generated.  Default is `100`.  The value `0` also equals the default.  The value specified is for this call only---the default keypool size is not changed
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Key Pool Size"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The new size of the keypool; if the number of keys in the keypool is less than this number, new keys will be generated.  Default is `100`.  The value `0` also equals the default.  The value specified is for this call only---the default keypool size is not changed"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | If the keypool is successfully filled, JSON `null` will be returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "If the keypool is successfully filled, JSON `null` will be returned"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listaccounts.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listaccounts.md
@@ -25,11 +25,18 @@ The `listaccounts` RPC {{summary_listAccounts}}
 
 *Result---a list of accounts and their balances*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | object          | Required<br>(exactly 1)     | A JSON array containing key/value pairs with account names and values.  Must include, at the very least, the default account ("")
-| →<br>Account : Balance | string : number (bitcoins) | Required<br>(1 or more) | The name of an account as a string paired with the balance of the account as a number of bitcoins.  The number of bitcoins may be negative if the account has spent more bitcoins than it received.  Accounts with zero balances and zero transactions will be displayed
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "A JSON array containing key/value pairs with account names and values.  Must include, at the very least, the default account (\"\")"
+
+- n: "→<br>Account : Balance"
+  t: "string : number (bitcoins)"
+  p: "Required<br>(1 or more)"
+  d: "The name of an account as a string paired with the balance of the account as a number of bitcoins.  The number of bitcoins may be negative if the account has spent more bitcoins than it received.  Accounts with zero balances and zero transactions will be displayed"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listaddressgroupings.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listaddressgroupings.md
@@ -19,15 +19,38 @@ The `listaddressgroupings` RPC {{summary_listAddressGroupings}}
 
 *Result---an array of arrays describing the groupings*
 
-| Name                   | Type              | Presence                    | Description
-|------------------------|-------------------|-----------------------------|----------------
-| `result`               | array             | Required<br>(exactly 1)     | An array containing the groupings.  May be empty
-| →<br>Groupings         | array             | Optional<br>(0 or more)     | An array containing arrays of addresses which can be associated with each other
-| → →<br>Address Details | array             | Required<br>(1 or more)     | An array containing information about a particular address
-| → → →<br>Address       | string (base58)   | Required<br>(exactly 1)     | The address in base58check format
-| → → →<br>Balance       | number (bitcoins) | Required<br>(exactly 1)     | The current spendable balance of the address, not counting unconfirmed transactions
-| → → →<br>Account       | string            | Optional<br>(0 or 1)        | The account the address belongs to, if any.  This field will not be returned for change addresses.  The default account is an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing the groupings.  May be empty"
+
+- n: "→<br>Groupings"
+  t: "array"
+  p: "Optional<br>(0 or more)"
+  d: "An array containing arrays of addresses which can be associated with each other"
+
+- n: "→ →<br>Address Details"
+  t: "array"
+  p: "Required<br>(1 or more)"
+  d: "An array containing information about a particular address"
+
+- n: "→ → →<br>Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The address in base58check format"
+
+- n: "→ → →<br>Balance"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The current spendable balance of the address, not counting unconfirmed transactions"
+
+- n: "→ → →<br>Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The account the address belongs to, if any.  This field will not be returned for change addresses.  The default account is an empty string (\"\")"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listlockunspent.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listlockunspent.md
@@ -19,13 +19,28 @@ The `listlockunspent` RPC {{summary_listLockUnspent}}
 
 *Result---an array of locked outputs*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | array           | Required<br>(exactly 1)      | An array containing all locked outputs.  May be empty
-| →<br>Output        | object          | Optional<br>(1 or more)     | An object describing a particular locked output
-| → →<br>`txid`      | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction containing the locked output, encoded as hex in RPC byte order
-| → →<br>`vout`      | number (int)    | Required<br>(exactly 1)     | The output index number (vout) of the locked output within the transaction.  Output index `0` is the first output within the transaction
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing all locked outputs.  May be empty"
+
+- n: "→<br>Output"
+  t: "object"
+  p: "Optional<br>(1 or more)"
+  d: "An object describing a particular locked output"
+
+- n: "→ →<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction containing the locked output, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number (vout) of the locked output within the transaction.  Output index `0` is the first output within the transaction"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listreceivedbyaccount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listreceivedbyaccount.md
@@ -21,10 +21,13 @@ The `listreceivedbyaccount` RPC {{summary_listReceivedByAccount}}
 
 *Parameter #2---whether to include empty accounts*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Include Empty      | bool            | Optional<br>(0 or 1)        | Set to `true` to display accounts which have never received a payment.  Set to `false` (the default) to only include accounts which have received a payment.  Any account which has received a payment will be displayed even if its current balance is `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Include Empty"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` to display accounts which have never received a payment.  Set to `false` (the default) to only include accounts which have received a payment.  Any account which has received a payment will be displayed even if its current balance is `0`"
+
+{% enditemplate %}
 
 *Parameter #3---whether to include watch-only addresses in results*
 
@@ -32,15 +35,38 @@ The `listreceivedbyaccount` RPC {{summary_listReceivedByAccount}}
 
 *Result---account names, balances, and minimum confirmations*
 
-| Name                       | Type              | Presence                    | Description
-|----------------------------|-------------------|-----------------------------|----------------
-| `result`                   | array             | Required<br>(exactly 1)     | An array containing objects each describing an account.  At the very least, the default account ("") will be included
-| →<br>Account               | object            | Required<br>(1 or more)     | An object describing an account
-| → →<br>`involvesWatchonly` | bool              | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the balance of this account includes a watch-only address which has received a spendable payment (that is, a payment with at least the specified number of confirmations and which is not an immature coinbase).  Otherwise not returned
-| → →<br>`account`           | string            | Required<br>(exactly 1)     | The name of the account
-| → →<br>`amount`<!--noref-->| number (bitcoins) | Required<br>(exactly 1)     | The total amount received by this account in bitcoins
-| → →<br>`confirmations`     | number (int)      | Required<br>(exactly 1)     | The number of confirmations received by the last transaction received by this account.  May be `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing objects each describing an account.  At the very least, the default account (\"\") will be included"
+
+- n: "→<br>Account"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing an account"
+
+- n: "→ →<br>`involvesWatchonly`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the balance of this account includes a watch-only address which has received a spendable payment (that is, a payment with at least the specified number of confirmations and which is not an immature coinbase).  Otherwise not returned"
+
+- n: "→ →<br>`account`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account"
+
+- n: "→ →<br>`amount`<!--noref-->"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The total amount received by this account in bitcoins"
+
+- n: "→ →<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations received by the last transaction received by this account.  May be `0`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listreceivedbyaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listreceivedbyaddress.md
@@ -21,10 +21,13 @@ The `listreceivedbyaddress` RPC {{summary_listReceivedByAddress}}
 
 *Parameter #2---whether to include empty accounts*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Include Empty      | bool            | Optional<br>(0 or 1)        | Set to `true` to display accounts which have never received a payment.  Set to `false` (the default) to only include accounts which have received a payment.  Any account which has received a payment will be displayed even if its current balance is `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Include Empty"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` to display accounts which have never received a payment.  Set to `false` (the default) to only include accounts which have received a payment.  Any account which has received a payment will be displayed even if its current balance is `0`"
+
+{% enditemplate %}
 
 *Parameter #3---whether to include watch-only addresses in results*
 
@@ -32,18 +35,53 @@ The `listreceivedbyaddress` RPC {{summary_listReceivedByAddress}}
 
 *Result---addresses, account names, balances, and minimum confirmations*
 
-| Name                       | Type              | Presence                    | Description
-|----------------------------|-------------------|-----------------------------|----------------
-| `result`                   | array             | Required<br>(exactly 1)     | An array containing objects each describing a particular address
-| →<br>Address               | object            | Optional<br>(0 or more)     | An object describing an address
-| → →<br>`involvesWatchonly` | bool              | Optional<br>(0 or 1)        | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if this address is a watch-only address which has received a spendable payment (that is, a payment with at least the specified number of confirmations and which is not an immature coinbase).  Otherwise not returned
-| → →<br>`address`           | string (base58)   | Required<br>(exactly 1)     | The address being described encoded in base58check
-| → →<br>`account`           | string            | Required<br>(exactly 1)     | The account the address belongs to; may be the default account, an empty string ("")
-| → →<br>`amount`            | number (bitcoins) | Required<br>(exactly 1)     | The total amount the address has received in bitcoins
-| → →<br>`confirmations`     | number (int)      | Required<br>(exactly 1)     | The number of confirmations of the latest transaction to the address.  May be `0` for unconfirmed
-| → →<br>TXIDs               | array             | Required<br>(exactly 1)     | An array of TXIDs belonging to transactions that pay the address
-| → → →<br>TXID              | string            | Optional<br>(0 or more)     | The TXID of a transaction paying the address, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing objects each describing a particular address"
+
+- n: "→<br>Address"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object describing an address"
+
+- n: "→ →<br>`involvesWatchonly`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if this address is a watch-only address which has received a spendable payment (that is, a payment with at least the specified number of confirmations and which is not an immature coinbase).  Otherwise not returned"
+
+- n: "→ →<br>`address`"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The address being described encoded in base58check"
+
+- n: "→ →<br>`account`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The account the address belongs to; may be the default account, an empty string (\"\")"
+
+- n: "→ →<br>`amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The total amount the address has received in bitcoins"
+
+- n: "→ →<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations of the latest transaction to the address.  May be `0` for unconfirmed"
+
+- n: "→ →<br>TXIDs"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of TXIDs belonging to transactions that pay the address"
+
+- n: "→ → →<br>TXID"
+  t: "string"
+  p: "Optional<br>(0 or more)"
+  d: "The TXID of a transaction paying the address, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listsinceblock.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listsinceblock.md
@@ -17,17 +17,23 @@ The `listsinceblock` RPC {{summary_listSinceBlock}}
 
 *Parameter #1---a block header hash*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Header Hash        | string (hex)    | Optional<br>(0 or 1)        | The hash of a block header encoded as hex in RPC byte order.  All transactions affecting the wallet which are not in that block or any earlier block will be returned, including unconfirmed transactions.  Default is the hash of the genesis block, so all transactions affecting the wallet are returned by default
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Header Hash"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The hash of a block header encoded as hex in RPC byte order.  All transactions affecting the wallet which are not in that block or any earlier block will be returned, including unconfirmed transactions.  Default is the hash of the genesis block, so all transactions affecting the wallet are returned by default"
+
+{% enditemplate %}
 
 *Parameter #2---the target confirmations for the lastblock field*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| Target Confirmations | number (int)    | Optional<br>(0 or 1)        | Sets the lastblock field of the results to the header hash of a block with this many confirmations.  This does not affect which transactions are returned.  Default is `1`, so the hash of the most recent block on the local best block chain is returned
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Target Confirmations"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Sets the lastblock field of the results to the header hash of a block with this many confirmations.  This does not affect which transactions are returned.  Default is `1`, so the hash of the most recent block on the local best block chain is returned"
+
+{% enditemplate %}
 
 *Parameter #3---whether to include watch-only addresses in details and calculations*
 
@@ -38,15 +44,30 @@ The `listsinceblock` RPC {{summary_listSinceBlock}}
 {% assign DEPTH="→ → → " %}
 {% include helpers/vars.md %}
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| `result`             | object          | Required<br>(exactly 1)     | An object containing an array of transactions and the lastblock field
-| →<br>`transactions`  | array           | Required<br>(exactly 1)     | An array of objects each describing a particular **payment** to or from this wallet.  The objects in this array do not describe an actual transactions, so more than one object in this array may come from the same transaction.  This array may be empty
-| → →<br>Payment       | object          | Optional<br>(0 or more)     | An payment which did not appear in the specified block or an earlier block
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing an array of transactions and the lastblock field"
+
+- n: "→<br>`transactions`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects each describing a particular **payment** to or from this wallet.  The objects in this array do not describe an actual transactions, so more than one object in this array may come from the same transaction.  This array may be empty"
+
+- n: "→ →<br>Payment"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An payment which did not appear in the specified block or an earlier block"
+
 {{INCLUDE_F_LIST_TRANSACTIONS}}
 {{INCLUDE_F_LIST_TRANSACTIONS_F_FULL}}
-| →<br>`lastblock`     | string (hex)    | Required<br>(exactly 1)     | The header hash of the block with the number of confirmations specified in the *target confirmations* parameter, encoded as hex in RPC byte order
-{:.ntpd}
+- n: "→<br>`lastblock`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The header hash of the block with the number of confirmations specified in the *target confirmations* parameter, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listtransactions.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listtransactions.md
@@ -17,24 +17,33 @@ The `listtransactions` RPC {{summary_listTransactions}}
 
 *Parameter #1---an account name to get transactions from*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | The name of an account to get transactinos from.  Use an empty string ("") to get transactions for the default account.  Default is `*` to get transactions for all accounts
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The name of an account to get transactinos from.  Use an empty string (\"\") to get transactions for the default account.  Default is `*` to get transactions for all accounts"
+
+{% enditemplate %}
 
 *Parameter #2---the number of transactions to get*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Count              | number (int)    | Optional<br>(0 or 1)        | The number of the most recent transactions to list.  Default is `10`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Count"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of the most recent transactions to list.  Default is `10`"
+
+{% enditemplate %}
 
 *Parameter #3---the number of transactions to skip*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Skip               | number (int)    | Optional<br>(0 or 1)        | The number of the most recent transactions which should not be returned.  Allows for pagination of results.  Default is `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Skip"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of the most recent transactions which should not be returned.  Allows for pagination of results.  Default is `0`"
+
+{% enditemplate %}
 
 *Parameter #4---whether to include watch-only addresses in details and calculations*
 
@@ -42,30 +51,113 @@ The `listtransactions` RPC {{summary_listTransactions}}
 
 *Result---payment details*
 
-| Name                     | Type              | Presence                    | Description
-|--------------------------|-------------------|----------------------------|----------------
-| `result`                 | array             | Required<br>(exactly 1)    | An array containing objects, with each object describing a **payment** or internal accounting entry (not a transaction).  More than one object in this array may come from a single transaction.  Array may be empty
-| →<br>Payment             | object            | Optional<br>(0 or more)    | A payment or internal accounting entry
-| → →<br>`account`         | string            | Required<br>(exactly 1)    | The account which the payment was credited to or debited from.  May be an empty string ("") for the default account
-| → →<br>`address`         | string (base58)   | Optional<br>(0 or 1)       | The address paid in this payment, which may be someone else's address not belonging to this wallet.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script or if this is in the *move* category
-| → →<br>`category`        | string            | Required<br>(exactly 1)    | Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain<br>• `move` if an off-block-chain move made with the `move` RPC
-| → →<br>`amount`          | number (bitcoins) | Required<br>(exactly 1)    | A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)
-| → →<br>`vout`            | number (int)      | Optional<br>(0 or 1)       | *Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index.  Not returned for *move* category payments
-| → →<br>`fee`             | number (bitcoins)| Optional<br>(0 or 1)        | If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment or for *move* category payments
-| → →<br>`confirmations`   | number (int)     | Optional<br>(0 or 1)        | The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted.  Not returned for *move* category payments
-| → →<br>`generated`       | bool             | Optional<br>(0 or 1)        | Set to `true` if the transaction is a coinbase.  Not returned for regular transactions or *move* category payments
-| → →<br>`blockhash`       | string (hex)     | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The hash of the block on the local best block chain which includes this transaction, encoded as hex in RPC byte order
-| → →<br>`blockindex`      | number (int)     | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The block height of the block on the local best block chain which includes this transaction
-| → →<br>`blocktime`       | number (int)     | Optional<br>(0 or 1)        | Only returned for confirmed transactions.  The block header time (Unix epoch time) of the block on the local best block chain which includes this transaction
-| → →<br>`txid`            | string (hex)     | Optional<br>(0 or 1)        | The TXID of the transaction, encoded as hex in RPC byte order.  Not returned for *move* category payments
-| → →<br>`walletconflicts` | array            | Optional<br>(0 or 1)        | An array containing the TXIDs of other transactions that spend the same inputs (UTXOs) as this transaction.  Array may be empty.  Not returned for *move* category payments
-| → → →<br>TXID            | string (hex)     | Optional<br>(0 or more)     | The TXID of a conflicting transaction, encoded as hex in RPC byte order
-| → →<br>`time`            | number (int)     | Required<br>(exactly 1)     | A Unix epoch time when the transaction was added to the wallet
-| → →<br>`timerecived`     | number (int)     | Optional<br>(0 or 1)        | A Unix epoch time when the transaction was detected by the local node, or the time of the block on the local best block chain that included the transaction.  Not returned for *move* category payments
-| → →<br>`comment`         | string           | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction.  Only returned in regular payments if a comment was added.  Always returned in *move* category payments.  May be an empty string
-| → →<br>`to`              | string           | Optional<br>(0 or 1)        | For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added.  Never returned by *move* category payments.  May be an empty string
-| → →<br>`otheraccount`    | string           | Optional<br>(0 or 1)        | Only returned by *move* category payments.  This is the account the bitcoins were moved from or moved to, as indicated by a negative or positive *amount* field in this payment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing objects, with each object describing a **payment** or internal accounting entry (not a transaction).  More than one object in this array may come from a single transaction.  Array may be empty"
+
+- n: "→<br>Payment"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "A payment or internal accounting entry"
+
+- n: "→ →<br>`account`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The account which the payment was credited to or debited from.  May be an empty string (\"\") for the default account"
+
+- n: "→ →<br>`address`"
+  t: "string (base58)"
+  p: "Optional<br>(0 or 1)"
+  d: "The address paid in this payment, which may be someone else's address not belonging to this wallet.  May be empty if the address is unknown, such as when paying to a non-standard pubkey script or if this is in the *move* category"
+
+- n: "→ →<br>`category`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "Set to one of the following values:<br>• `send` if sending payment<br>• `receive` if this wallet received payment in a regular transaction<br>• `generate` if a matured and spendable coinbase<br>• `immature` if a coinbase that is not spendable yet<br>• `orphan` if a coinbase from a block that's not in the local best block chain<br>• `move` if an off-block-chain move made with the `move` RPC"
+
+- n: "→ →<br>`amount`"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "A negative bitcoin amount if sending payment; a positive bitcoin amount if receiving payment (including coinbases)"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>For an output, the output index (vout) for this output in this transaction.  For an input, the output index for the output being spent in its transaction.  Because inputs list the output indexes from previous transactions, more than one entry in the details array may have the same output index.  Not returned for *move* category payments"
+
+- n: "→ →<br>`fee`"
+  t: "number (bitcoins)"
+  p: "Optional<br>(0 or 1)"
+  d: "If sending payment, the fee paid as a negative bitcoins value.  May be `0`. Not returned if receiving payment or for *move* category payments"
+
+- n: "→ →<br>`confirmations`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of confirmations the transaction has received.  Will be `0` for unconfirmed and `-1` for conflicted.  Not returned for *move* category payments"
+
+- n: "→ →<br>`generated`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if the transaction is a coinbase.  Not returned for regular transactions or *move* category payments"
+
+- n: "→ →<br>`blockhash`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The hash of the block on the local best block chain which includes this transaction, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`blockindex`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The block height of the block on the local best block chain which includes this transaction"
+
+- n: "→ →<br>`blocktime`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for confirmed transactions.  The block header time (Unix epoch time) of the block on the local best block chain which includes this transaction"
+
+- n: "→ →<br>`txid`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The TXID of the transaction, encoded as hex in RPC byte order.  Not returned for *move* category payments"
+
+- n: "→ →<br>`walletconflicts`"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "An array containing the TXIDs of other transactions that spend the same inputs (UTXOs) as this transaction.  Array may be empty.  Not returned for *move* category payments"
+
+- n: "→ → →<br>TXID"
+  t: "string (hex)"
+  p: "Optional<br>(0 or more)"
+  d: "The TXID of a conflicting transaction, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`time`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "A Unix epoch time when the transaction was added to the wallet"
+
+- n: "→ →<br>`timerecived`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "A Unix epoch time when the transaction was detected by the local node, or the time of the block on the local best block chain that included the transaction.  Not returned for *move* category payments"
+
+- n: "→ →<br>`comment`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "For transaction originating with this wallet, a locally-stored comment added to the transaction.  Only returned in regular payments if a comment was added.  Always returned in *move* category payments.  May be an empty string"
+
+- n: "→ →<br>`to`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "For transaction originating with this wallet, a locally-stored comment added to the transaction identifying who the transaction was sent to.  Only returned if a comment-to was added.  Never returned by *move* category payments.  May be an empty string"
+
+- n: "→ →<br>`otheraccount`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned by *move* category payments.  This is the account the bitcoins were moved from or moved to, as indicated by a negative or positive *amount* field in this payment"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/listunspent.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/listunspent.md
@@ -19,42 +19,98 @@ the *spendable* field in the results described below.
 
 *Parameter #1---the minimum number of confirmations an output must have*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Minimum Confirmations | number (int) | Optional<br>(0 or 1)        | The minimum number of confirmations the transaction containing an output must have in order to be returned.  Use `0` to return outputs from unconfirmed transactions. Default is `1`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Minimum Confirmations"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The minimum number of confirmations the transaction containing an output must have in order to be returned.  Use `0` to return outputs from unconfirmed transactions. Default is `1`"
+
+{% enditemplate %}
 
 *Parameter #2---the maximum number of confirmations an output may have*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Maximum Confirmations | number (int) | Optional<br>(0 or 1)        | The maximum number of confirmations the transaction containing an output may have in order to be returned.  Default is `9999999` (~10 million)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Maximum Confirmations"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The maximum number of confirmations the transaction containing an output may have in order to be returned.  Default is `9999999` (~10 million)"
+
+{% enditemplate %}
 
 *Parameter #3---the addresses an output must pay*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Addresses          | array           | Optional<br>(0 or 1)        | If present, only outputs which pay an address in this array will be returned
-| →<br>Address       | string (base58) | Required<br>(1 or more)     | A P2PKH or P2SH address
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Addresses"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "If present, only outputs which pay an address in this array will be returned"
+
+- n: "→<br>Address"
+  t: "string (base58)"
+  p: "Required<br>(1 or more)"
+  d: "A P2PKH or P2SH address"
+
+{% enditemplate %}
 
 *Result---the list of unspent outputs*
 
-| Name                   | Type            | Presence                    | Description
-|------------------------|-----------------|-----------------------------|----------------
-| `result`               | array           | Required<br>(exactly 1)     | An array of objects each describing an unspent output.  May be empty
-| →<br>Unspent Output    | object          | Optional<br>(0 or more)     | An object describing a particular unspent output belonging to this wallet
-| → →<br>`txid`          | string (hex)    | Required<br>(exactly 1)     | The TXID of the transaction containing the output, encoded as hex in RPC byte order
-| → →<br>`vout`          | number (int)    | Required<br>(exactly 1)     | The output index number (vout) of the output within its containing transaction
-| → →<br>`address`       | string (base58) | Optional<br>(0 or 1)        | The P2PKH or P2SH address the output paid.  Only returned for P2PKH or P2SH output scripts
-| → →<br>`account`       | string          | Optional<br>(0 or 1)        | If the address returned belongs to an account, this is the account.  Otherwise not returned
-| → →<br>`scriptPubKey`  | string (hex)    | Required<br>(exactly 1)     | The output script paid, encoded as hex
-| → →<br>`redeemScript`  | string (hex)    | Optional<br>(0 or 1)        | If the output is a P2SH whose script belongs to this wallet, this is the redeem script
-| → →<br>`amount`        | number (int)    | Required<br>(exactly 1)     | The amount paid to the output in bitcoins
-| → →<br>`confirmations` | number (int)    | Required<br>(exactly 1)     | The number of confirmations received for the transaction containing this output
-| → →<br>`spendable`     | bool            | Required<br>(exactly 1)     | *Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the private key or keys needed to spend this output are part of the wallet.  Set to `false` if not (such as for watch-only addresses)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array of objects each describing an unspent output.  May be empty"
+
+- n: "→<br>Unspent Output"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An object describing a particular unspent output belonging to this wallet"
+
+- n: "→ →<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction containing the output, encoded as hex in RPC byte order"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number (vout) of the output within its containing transaction"
+
+- n: "→ →<br>`address`"
+  t: "string (base58)"
+  p: "Optional<br>(0 or 1)"
+  d: "The P2PKH or P2SH address the output paid.  Only returned for P2PKH or P2SH output scripts"
+
+- n: "→ →<br>`account`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "If the address returned belongs to an account, this is the account.  Otherwise not returned"
+
+- n: "→ →<br>`scriptPubKey`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The output script paid, encoded as hex"
+
+- n: "→ →<br>`redeemScript`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the output is a P2SH whose script belongs to this wallet, this is the redeem script"
+
+- n: "→ →<br>`amount`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The amount paid to the output in bitcoins"
+
+- n: "→ →<br>`confirmations`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of confirmations received for the transaction containing this output"
+
+- n: "→ →<br>`spendable`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "*Added in Bitcoin Core 0.10.0*<br><br>Set to `true` if the private key or keys needed to spend this output are part of the wallet.  Set to `false` if not (such as for watch-only addresses)"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/lockunspent.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/lockunspent.md
@@ -17,27 +17,48 @@ The `lockunspent` RPC {{summary_lockUnspent}}
 
 *Parameter #1---whether to lock or unlock the outputs*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| Lock Or Unlock       | bool            | Required<br>(exactly 1)     | Set to `true` to lock the outputs specified in the following parameter.  Set to `false` to unlock the outputs specified.  If this is the only argument specified, all outputs will be unlocked (even if this is set to `false`)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Lock Or Unlock"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` to lock the outputs specified in the following parameter.  Set to `false` to unlock the outputs specified.  If this is the only argument specified, all outputs will be unlocked (even if this is set to `false`)"
+
+{% enditemplate %}
 
 *Parameter #2---the outputs to lock or unlock*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| Outputs              | array           | Optional<br>(0 or 1)        | An array of outputs to lock or unlock
-| →<br>Output          | object          | Required<br>(1 or more)     | An object describing a particular output
-| → →<br>`txid`        | string          | Required<br>(exactly 1)     | The TXID of the transaction containing the output to lock or unlock, encoded as hex in internal byte order
-| → →<br>`vout`        | number (int)    | Required<br>(exactly 1)     | The output index number (vout) of the output to lock or unlock.  The first output in a transaction has an index of `0`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Outputs"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "An array of outputs to lock or unlock"
+
+- n: "→<br>Output"
+  t: "object"
+  p: "Required<br>(1 or more)"
+  d: "An object describing a particular output"
+
+- n: "→ →<br>`txid`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction containing the output to lock or unlock, encoded as hex in internal byte order"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The output index number (vout) of the output to lock or unlock.  The first output in a transaction has an index of `0`"
+
+{% enditemplate %}
 
 *Result---`true` if successful*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| `result`             | bool            | Required<br>(exactly 1)     | Set to `true` if the outputs were successfully locked or unlocked
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the outputs were successfully locked or unlocked"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/move.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/move.md
@@ -22,45 +22,63 @@ account a balance that may exceed the number of bitcoins in the wallet
 
 *Parameter #1---from account*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| From Account         | string          | Required<br>(exactly 1)     | The name of the account to move the funds from
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "From Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account to move the funds from"
+
+{% enditemplate %}
 
 *Parameter #2---to account*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| To Account           | string          | Required<br>(exactly 1)     | The name of the account to move the funds to
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "To Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account to move the funds to"
+
+{% enditemplate %}
 
 *Parameter #3---amount to move*
 
-| Name                 | Type              | Presence                    | Description
-|----------------------|-------------------|-----------------------------|----------------
-| Amount               | number (bitcoins) | Required<br>(exactly 1)     | The amount of bitcoins to move
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Amount"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The amount of bitcoins to move"
+
+{% enditemplate %}
 
 *Parameter #4---an unused parameter*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| *Unused*             | number (int)    | Optional<br>(0 or 1)        | This parameter is no longer used. If parameter #5 needs to be specified, this can be any integer
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "*Unused*"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "This parameter is no longer used. If parameter #5 needs to be specified, this can be any integer"
+
+{% enditemplate %}
 
 *Parameter #5---a comment*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| Comment              | string          | Optional<br>(0 or 1)        | A comment to assign to this move payment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A comment to assign to this move payment"
+
+{% enditemplate %}
 
 *Result---`true` on success*
 
-| Name                 | Type            | Presence                    | Description
-|----------------------|-----------------|-----------------------------|----------------
-| `result`             | bool            | Required<br>(exactly 1)     | Set to `true` if the move was successful
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the move was successful"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/ping.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/ping.md
@@ -17,10 +17,13 @@ The `ping` RPC {{summary_ping-rpc}}
 
 *Result---`null`*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required                    | Always JSON `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required"
+  d: "Always JSON `null`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/prioritisetransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/prioritisetransaction.md
@@ -17,31 +17,43 @@ The `prioritisetransaction` RPC {{summary_prioritiseTransaction}}
 
 *Parameter #1---the TXID of the transaction to modify*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| TXID               | string          | Required<br>(exactly 1)     | The TXID of the transaction whose virtual priority or fee you want to modify, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "TXID"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction whose virtual priority or fee you want to modify, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Parameter #2---the change to make to the virtual priority*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| Priority           | number (real)     | Required<br>(exactly 1)     | If positive, the priority to add to the transaction in addition to its computed priority; if negative, the priority to subtract from the transaction's computed priory.  Computed priority is the age of each input in days since it was added to the block chain as an output (coinage) times the value of the input in satoshis (value) divided by the size of the serialized transaction (size), which is `coinage * value / size`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Priority"
+  t: "number (real)"
+  p: "Required<br>(exactly 1)"
+  d: "If positive, the priority to add to the transaction in addition to its computed priority; if negative, the priority to subtract from the transaction's computed priory.  Computed priority is the age of each input in days since it was added to the block chain as an output (coinage) times the value of the input in satoshis (value) divided by the size of the serialized transaction (size), which is `coinage * value / size`"
+
+{% enditemplate %}
 
 *Parameter #3---the change to make to the virtual fee*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Fee                | number (int)    | Required<br>(exactly 1)     | **Warning:** this value is in satoshis, not bitcoins<br><br>If positive, the virtual fee to add to the actual fee paid by the transaction; if negative, the virtual fee to subtract from the actual fee paid by the transaction.  No change is made to the actual fee paid by the transaction
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Fee"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "**Warning:** this value is in satoshis, not bitcoins<br><br>If positive, the virtual fee to add to the actual fee paid by the transaction; if negative, the virtual fee to subtract from the actual fee paid by the transaction.  No change is made to the actual fee paid by the transaction"
+
+{% enditemplate %}
 
 *Result---`true` if the priority is changed*
 
-| Name               | Type             | Presence                    | Description
-|--------------------|------------------|-----------------------------|----------------
-| `result`           | bool (true only) | Required<br>(exactly 1)     | Always set to `true` if all three parameters are provided.  Will not return an error if the TXID is not in the memory pool.  If fewer or more than three arguments are provided, or if something goes wrong, will be set to `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool (true only)"
+  p: "Required<br>(exactly 1)"
+  d: "Always set to `true` if all three parameters are provided.  Will not return an error if the TXID is not in the memory pool.  If fewer or more than three arguments are provided, or if something goes wrong, will be set to `null`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/sendfrom.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/sendfrom.md
@@ -18,24 +18,33 @@ The `sendfrom` RPC {{summary_sendFrom}}
 
 *Parameter #1---from account*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| From Account       | string          | Required<br>(exactly 1)     | The name of the account from which the bitcoins should be spent.  Use an empty string ("") for the default account
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "From Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account from which the bitcoins should be spent.  Use an empty string (\"\") for the default account"
+
+{% enditemplate %}
 
 *Parameter #2---to address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| To Address         | string          | Required<br>(exactly 1)     | A P2PKH or P2SH address to which the bitcoins should be sent
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "To Address"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH or P2SH address to which the bitcoins should be sent"
+
+{% enditemplate %}
 
 *Parameter #3---amount to spend*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|---------------
-| Amount             | number (bitcoins) | Required<br>(exactly 1)     | The amount to spend in bitcoins.  Bitcoin Core will ensure the account has sufficient bitcoins to pay this amount (but the transaction fee paid is not included in the calculation, so an account can spend a total of its balance plus the transaction fee)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Amount"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The amount to spend in bitcoins.  Bitcoin Core will ensure the account has sufficient bitcoins to pay this amount (but the transaction fee paid is not included in the calculation, so an account can spend a total of its balance plus the transaction fee)"
+
+{% enditemplate %}
 
 *Parameter #4---minimum confirmations*
 
@@ -43,24 +52,33 @@ The `sendfrom` RPC {{summary_sendFrom}}
 
 *Parameter #5---a comment*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Comment            | string          | Optional<br>(0 or 1)        | A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment"
+
+{% enditemplate %}
 
 *Parameter #6---a comment about who the payment was sent to*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Comment To         | string          | Optional<br>(0 or 1)        | A locally-stored (not broadcast) comment assigned to this transaction.  Meant to be used for describing who the payment was sent to. Default is no comment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment To"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A locally-stored (not broadcast) comment assigned to this transaction.  Meant to be used for describing who the payment was sent to. Default is no comment"
+
+{% enditemplate %}
 
 *Result---a TXID of the sent transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | string          | Required<br>(exactly 1)     | The TXID of the sent transaction, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the sent transaction, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/sendmany.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/sendmany.md
@@ -18,18 +18,28 @@ The `sendmany` RPC {{summary_sendMany}}
 
 *Parameter #1---from account*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| From Account       | string          | Required<br>(exactly 1)     | The name of the account from which the bitcoins should be spent.  Use an empty string ("") for the default account. Bitcoin Core will ensure the account has sufficient bitcoins to pay the total amount in the *outputs* field described below (but the transaction fee paid is not included in the calculation, so an account can spend a total of its balance plus the transaction fee)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "From Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account from which the bitcoins should be spent.  Use an empty string (\"\") for the default account. Bitcoin Core will ensure the account has sufficient bitcoins to pay the total amount in the *outputs* field described below (but the transaction fee paid is not included in the calculation, so an account can spend a total of its balance plus the transaction fee)"
+
+{% enditemplate %}
 
 *Parameter #2---the addresses and amounts to pay*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Outputs            | object          | Required<br>(exactly 1)     | An object containing key/value pairs corresponding to the addresses and amounts to pay
-| →<br>Address/Amount | string (base58) : number (bitcoins) | Required<br>(1 or more) | A key/value pair with a base58check-encoded string containing the P2PKH or P2SH address to pay as the key, and an amount of bitcoins to pay as the value
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Outputs"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "An object containing key/value pairs corresponding to the addresses and amounts to pay"
+
+- n: "→<br>Address/Amount"
+  t: "string (base58) : number (bitcoins)"
+  p: "Required<br>(1 or more)"
+  d: "A key/value pair with a base58check-encoded string containing the P2PKH or P2SH address to pay as the key, and an amount of bitcoins to pay as the value"
+
+{% enditemplate %}
 
 *Parameter #3---minimum confirmations*
 
@@ -37,17 +47,23 @@ The `sendmany` RPC {{summary_sendMany}}
 
 *Parameter #4---a comment*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Comment            | string          | Optional<br>(0 or 1)        | A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment"
+
+{% enditemplate %}
 
 *Result---a TXID of the sent transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | string          | Required<br>(exactly 1)     | The TXID of the sent transaction, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the sent transaction, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/sendrawtransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/sendrawtransaction.md
@@ -15,24 +15,33 @@ The `sendrawtransaction` RPC {{summary_sendRawTransaction}}
 
 *Parameter #1---a serialized transaction to broadcast*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Transaction        | string (hex)    | Required<br>(exactly 1)     | The serialized transaction to broadcast encoded as hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Transaction"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The serialized transaction to broadcast encoded as hex"
+
+{% enditemplate %}
 
 *Parameter #2--whether to allow high fees**
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Allow High Fees    | bool            | Optional<br>(0 or 1)        | Set to `true` to allow the transaction to pay a high transaction fee.  Set to `false` (the default) to prevent Bitcoin Core from broadcasting the transaction if it includes a high fee.  Transaction fees are the sum of the inputs minus the sum of the outputs, so this high fees check helps ensures user including a change address to return most of the difference back to themselves
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Allow High Fees"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` to allow the transaction to pay a high transaction fee.  Set to `false` (the default) to prevent Bitcoin Core from broadcasting the transaction if it includes a high fee.  Transaction fees are the sum of the inputs minus the sum of the outputs, so this high fees check helps ensures user including a change address to return most of the difference back to themselves"
+
+{% enditemplate %}
 
 *Result---a TXID or error message*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|----------------
-| `result`           | null/string (hex) | Required<br>(exactly 1)     | If the transaction was accepted by the node for broadcast, this will be the TXID of the transaction encoded as hex in RPC byte order.  If the transaction was rejected by the node, this will set to `null`, the JSON-RPC error field will be set to a code, and the JSON-RPC message field may contain an informative error message
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null/string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "If the transaction was accepted by the node for broadcast, this will be the TXID of the transaction encoded as hex in RPC byte order.  If the transaction was rejected by the node, this will set to `null`, the JSON-RPC error field will be set to a code, and the JSON-RPC message field may contain an informative error message"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/sendtoaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/sendtoaddress.md
@@ -18,38 +18,53 @@ The `sendtoaddress` RPC {{summary_sendToAddress}}
 
 *Parameter #1---to address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| To Address         | string          | Required<br>(exactly 1)     | A P2PKH or P2SH address to which the bitcoins should be sent
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "To Address"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH or P2SH address to which the bitcoins should be sent"
+
+{% enditemplate %}
 
 *Parameter #2---amount to spend*
 
-| Name               | Type              | Presence                    | Description
-|--------------------|-------------------|-----------------------------|---------------
-| Amount             | number (bitcoins) | Required<br>(exactly 1)     | The amount to spent in bitcoins
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Amount"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The amount to spent in bitcoins"
+
+{% enditemplate %}
 
 *Parameter #3---a comment*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Comment            | string          | Optional<br>(0 or 1)        | A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A locally-stored (not broadcast) comment assigned to this transaction.  Default is no comment"
+
+{% enditemplate %}
 
 *Parameter #4---a comment about who the payment was sent to*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Comment To         | string          | Optional<br>(0 or 1)        | A locally-stored (not broadcast) comment assigned to this transaction.  Meant to be used for describing who the payment was sent to. Default is no comment
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Comment To"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "A locally-stored (not broadcast) comment assigned to this transaction.  Meant to be used for describing who the payment was sent to. Default is no comment"
+
+{% enditemplate %}
 
 *Result---a TXID of the sent transaction*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | string          | Required<br>(exactly 1)     | The TXID of the sent transaction, encoded as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the sent transaction, encoded as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/setaccount.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/setaccount.md
@@ -17,24 +17,33 @@ The `setaccount` RPC {{summary_setAccount}}
 
 *Parameter #1---a bitcoin address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Address            | string (base58) | Required<br>(exactly 1)     | The P2PKH or P2SH address to put in the account.  Must already belong to the wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2PKH or P2SH address to put in the account.  Must already belong to the wallet"
+
+{% enditemplate %}
 
 *Parameter #2---an account*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Account            | string          | Required<br>(exactly 1)     | The name of the account in which the address should be placed.  May be the default account, an empty string ("")
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Account"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The name of the account in which the address should be placed.  May be the default account, an empty string (\"\")"
+
+{% enditemplate %}
 
 *Result---`null` if successful*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | null            | Required<br>(exactly 1)     | Set to JSON `null` if the address was successfully placed in the account
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Set to JSON `null` if the address was successfully placed in the account"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/setgenerate.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/setgenerate.md
@@ -17,39 +17,58 @@ The `setgenerate` RPC {{summary_setGenerate}}
 
 *Parameter #1---whether to enable or disable generation*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Enable/Disable     | bool            | Required<br>(exactly 1)     | Set to `true` to enable generation; set to `false` to disable generation
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Enable/Disable"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` to enable generation; set to `false` to disable generation"
+
+{% enditemplate %}
 
 *Parameter #2 (regular)---the number of processors to use*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Processors         | number (int)    | Optional<br>(0 or 1)        | The number of processors to use.  Defaults to `1`.  Set to `-1` to use all processors
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Processors"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of processors to use.  Defaults to `1`.  Set to `-1` to use all processors"
+
+{% enditemplate %}
 
 *Parameter #2 (regtest)---the number of blocks to generate*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Blocks             | number (int)    | Optional<br>(0 or 1)        | In regtest mode, set to the number of blocks to generate.  Defaults to `1`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Blocks"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "In regtest mode, set to the number of blocks to generate.  Defaults to `1`"
+
+{% enditemplate %}
 
 *Result (regular)---generating is enabled*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null            | Required<br>(exactly 1)     | Always JSON `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always JSON `null`"
+
+{% enditemplate %}
 
 *Result (regtest)---the generated block header hashes*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| `result`            | array/null      | Required<br>(exactly 1)     | An array containing the block header hashes of the generated blocks, or JSON `null` if no blocks were generated
-| →<br>Header Hashes  | string (hex)    | Required<br>(1 or more)     | The hashes of the headers of the blocks generated in regtest mode, as hex in RPC byte order
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array/null"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing the block header hashes of the generated blocks, or JSON `null` if no blocks were generated"
+
+- n: "→<br>Header Hashes"
+  t: "string (hex)"
+  p: "Required<br>(1 or more)"
+  d: "The hashes of the headers of the blocks generated in regtest mode, as hex in RPC byte order"
+
+{% enditemplate %}
 
 *Examples from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/settxfee.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/settxfee.md
@@ -17,17 +17,23 @@ The `settxfee` RPC {{summary_setTxFee}}
 
 *Parameter #1---the transaction fee amount per kilobyte*
 
-| Name                         | Type              | Presence                    | Description
-|------------------------------|-------------------|-----------------------------|---------------
-| Transaction Fee Per Kilobyte | number (bitcoins) | Required<br>(exactly 1)     | The transaction fee to pay, in bitcoins, for each kilobyte of transaction data.  The value `0` will not be accepted.  Be careful setting the fee too low---your transactions may not be relayed or included in blocks
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Transaction Fee Per Kilobyte"
+  t: "number (bitcoins)"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction fee to pay, in bitcoins, for each kilobyte of transaction data.  The value `0` will not be accepted.  Be careful setting the fee too low---your transactions may not be relayed or included in blocks"
+
+{% enditemplate %}
 
 *Result: `true` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | bool (true)     | Required<br>(exactly 1)     | Set to `true` if the fee was successfully set
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool (true)"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the fee was successfully set"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/signmessage.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/signmessage.md
@@ -18,24 +18,33 @@ The `signmessage` RPC {{summary_signMessage}}
 
 *Parameter #1---the address corresponding to the private key to sign with*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Address            | string (base58) | Required<br>(exactly 1)     | A P2PKH address whose private key belongs to this wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "A P2PKH address whose private key belongs to this wallet"
+
+{% enditemplate %}
 
 *Parameter #2---the message to sign*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Message            | string          | Required<br>(exactly 1)     | The message to sign
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Message"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The message to sign"
+
+{% enditemplate %}
 
 *Result---the message signature*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | string (base64) | Required<br>(exactly 1)     | The signature of the message, encoded in base64.  Note that Bitcoin Core before 0.10.0 creates signatures with random *k* values, so each time you sign the same message, it will create a different signature
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string (base64)"
+  p: "Required<br>(exactly 1)"
+  d: "The signature of the message, encoded in base64.  Note that Bitcoin Core before 0.10.0 creates signatures with random *k* values, so each time you sign the same message, it will create a different signature"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/signrawtransaction.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/signrawtransaction.md
@@ -15,46 +15,93 @@ The `signrawtransaction` RPC {{summary_signRawTransaction}}
 
 *Parameter #1---the transaction to sign*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|----------------
-| Transaction      | string (hex  | Required<br>(exactly 1)     | The transaction to sign as a serialized transaction
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Transaction"
+  t: "string (hex"
+  p: "Required<br>(exactly 1)"
+  d: "The transaction to sign as a serialized transaction"
+
+{% enditemplate %}
 
 *Parameter #2---unspent transaction output details*
 
-| Name                  | Type         | Presence                    | Description
-|-----------------------|--------------|-----------------------------|-------------
-| Dependencies          | array        | Optional<br>(0 or 1)        | The previous outputs being spent by this transaction
-| →<br>Output           | object       | Optional<br>(0 or more)     | An output being spent
-| → →<br>`txid`         | string (hex) | Required<br>(exactly 1)     | The TXID of the transaction the output appeared in.  The TXID must be encoded in hex in RPC byte order
-| → →<br>`vout`         | number (int) | Required<br>(exactly 1)     | The index number of the output (vout) as it appeared in its transaction, with the first output being 0
-| → →<br>`scriptPubKey` | string (hex) | Required<br>(exactly 1)     | The output's pubkey script encoded as hex
-| → →<br>`redeemScript` | string (hex) | Optional<br>(0 or 1)        | If the pubkey script was a script hash, this must be the corresponding redeem script
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Dependencies"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "The previous outputs being spent by this transaction"
+
+- n: "→<br>Output"
+  t: "object"
+  p: "Optional<br>(0 or more)"
+  d: "An output being spent"
+
+- n: "→ →<br>`txid`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The TXID of the transaction the output appeared in.  The TXID must be encoded in hex in RPC byte order"
+
+- n: "→ →<br>`vout`"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The index number of the output (vout) as it appeared in its transaction, with the first output being 0"
+
+- n: "→ →<br>`scriptPubKey`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The output's pubkey script encoded as hex"
+
+- n: "→ →<br>`redeemScript`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the pubkey script was a script hash, this must be the corresponding redeem script"
+
+{% enditemplate %}
 
 *Parameter #3---private keys for signing*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|-------------
-| Private Keys     | array           | Optional<br>(0 or 1)        | An array holding private keys.  If any keys are provided, only they will be used to sign the transaction (even if the wallet has other matching keys).  If this array is empty or not used, and wallet support is enabled, keys from the wallet will be used
-| →<br>Key         | string (base58) | Required<br>(1 or more)     | A private key in base58check format to use to create a signature for this transaction
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Private Keys"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "An array holding private keys.  If any keys are provided, only they will be used to sign the transaction (even if the wallet has other matching keys).  If this array is empty or not used, and wallet support is enabled, keys from the wallet will be used"
+
+- n: "→<br>Key"
+  t: "string (base58)"
+  p: "Required<br>(1 or more)"
+  d: "A private key in base58check format to use to create a signature for this transaction"
+
+{% enditemplate %}
 
 *Parameter #4---signature hash type*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|-------------
-| SigHash          | string       | Optional<br>(0 or 1)        | The type of signature hash to use for all of the signatures performed.  (You must use separate calls to the `signrawtransaction` RPC if you want to use different signature hash types for different signatures.  The allowed values are: `ALL`, `NONE`, `SINGLE`, `ALL|ANYONECANPAY`, `NONE|ANYONECANPAY`, and `SINGLE|ANYONECANPAY`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "SigHash"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The type of signature hash to use for all of the signatures performed.  (You must use separate calls to the `signrawtransaction` RPC if you want to use different signature hash types for different signatures.  The allowed values are: `ALL`, `NONE`, `SINGLE`, `ALL|ANYONECANPAY`, `NONE|ANYONECANPAY`, and `SINGLE|ANYONECANPAY`"
+
+{% enditemplate %}
 
 *Result---the transaction with any signatures made*
 
-| Name             | Type         | Presence                    | Description
-|------------------|--------------|-----------------------------|-------------
-| `result`         | object       | Required<br>(exactly 1)     | The results of the signature
-| →<br>`hex`       | string (hex) | Required<br>(exactly 1)     | The resulting serialized transaction encoded as hex with any signatures made inserted.  If no signatures were made, this will be the same transaction provided in parameter #1
-| →<br>`complete`  | bool         | Required<br>(exactly 1)     | The value `true` if transaction is fully signed; the value `false` if more signatures are required
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "The results of the signature"
+
+- n: "→<br>`hex`"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The resulting serialized transaction encoded as hex with any signatures made inserted.  If no signatures were made, this will be the same transaction provided in parameter #1"
+
+- n: "→<br>`complete`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "The value `true` if transaction is fully signed; the value `false` if more signatures are required"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/stop.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/stop.md
@@ -17,10 +17,13 @@ The `stop` RPC {{summary_stop}}
 
 *Result---the server is safely shut down*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | string          | Required<br>(exactly 1)     | The string "Bitcoin server stopping"
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The string \"Bitcoin server stopping\""
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/submitblock.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/submitblock.md
@@ -15,24 +15,33 @@ The `submitblock` RPC {{summary_submitBlock}}
 
 *Parameter #1---the new block in serialized block format as hex*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Block              | string (hex)    | Required<br>(exactly 1)     | The full block to submit in serialized block format as hex
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Block"
+  t: "string (hex)"
+  p: "Required<br>(exactly 1)"
+  d: "The full block to submit in serialized block format as hex"
+
+{% enditemplate %}
 
 *Parameter #2---additional parameters*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Parameters         | object          | Optional<br>(0 or 1)        | A JSON object containing extra parameters.  Not used directly by Bitcoin Core and also not broadcast to the network.  This is available for use by mining pools and other software.  A common parameter is a `workid` string
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Parameters"
+  t: "object"
+  p: "Optional<br>(0 or 1)"
+  d: "A JSON object containing extra parameters.  Not used directly by Bitcoin Core and also not broadcast to the network.  This is available for use by mining pools and other software.  A common parameter is a `workid` string"
+
+{% enditemplate %}
 
 *Result---`null` or error string*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | null/string     | Required<br>(exactly 1)     | If the block submission succeeded, set to JSON `null`.  If submission failed, set to one of the following strings: `duplicate`, `duplicate-invalid`, `inconclusive`, or `rejected`.  The JSON-RPC `error` field will still be set to `null` if submission failed for one of these reasons
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null/string"
+  p: "Required<br>(exactly 1)"
+  d: "If the block submission succeeded, set to JSON `null`.  If submission failed, set to one of the following strings: `duplicate`, `duplicate-invalid`, `inconclusive`, or `rejected`.  The JSON-RPC `error` field will still be set to `null` if submission failed for one of these reasons"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/validateaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/validateaddress.md
@@ -15,30 +15,88 @@ The `validateaddress` RPC {{summary_validateAddress}}
 
 *Parameter #1---a P2PKH or P2SH address*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Address            | string (base58) | Required<br>(exactly 1) | The P2PKH or P2SH address to validate encoded in base58check format
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2PKH or P2SH address to validate encoded in base58check format"
+
+{% enditemplate %}
 
 *Result---information about the address*
 
-| Name                | Type            | Presence                    | Description
-|---------------------|-----------------|-----------------------------|----------------
-| `result`            | object          | Required<br>(exactly 1)     | Information about the address
-| →<br>`isvalid`      | bool            | Required<br>(exactly 1)     | Set to `true` if the address is a valid P2PKH or P2SH address; set to `false` otherwise
-| →<br>`address`      | string (base58) | Optional<br>(0 or 1)   | If the address is valid, this is the address <!--TODO: figure out in what cases this might be different from the address provided in the parameter -->
-| →<br>`ismine`       | bool            | Optional<br>(0 or 1)        | Set to `true` if the address belongs to the wallet; set to false if it does not.  Only returned if wallet support enabled
-| →<br>`iswatchonly`  | bool            | Optional<br>(0 or 1)        | Set to `true` if the address is watch-only.  Otherwise set to `false`.  Only returned if address is in the wallet
-| →<br>`isscript`     | bool            | Optional<br>(0 or 1)        | Set to `true` if a P2SH address; otherwise set to `false`.  Only returned if the address is in the wallet
-| →<br>`script`       | string          | Optional<br>(0 or 1)        | Only returned for P2SH addresses belonging to this wallet. This is the type of script:<br>• `pubkey` for a P2PK script inside P2SH<br>• `pubkeyhash` for a P2PKH script inside P2SH<br>• `multisig` for a multisig script inside P2SH<br>• `nonstandard` for unknown scripts
-| →<br>`hex`          | string (hex)    | Optional<br>(0 or 1)        | Only returned for P2SH addresses belonging to this wallet.  This is the redeem script encoded as hex
-| →<br>`addresses`    | array           | Optional<br>(0 or 1)        | Only returned for P2SH addresses belonging to the wallet.  A P2PKH addresses used in this script, or the computed P2PKH addresses of any pubkeys in this script.  This array will be empty for `nonstandard` script types
-| → →<br>Address      | string          | Optional<br>(0 or more)     | A P2PKH address
-| →<br>`sigrequired`  | number (int)    | Optional<br>(0 or 1)        | Only returned for multisig P2SH addresses belonging to the wallet.  The number of signatures required by this script
-| →<br>`pubkey`       | string (hex)    | Optional<br>(0 or 1)        | The public key corresponding to this address.  Only returned if the address is a P2PKH address in the wallet
-| →<br>`iscompressed` | bool            | Optional<br>(0 or 1)        | Set to `true` if a compressed public key or set to `false` if an uncompressed public key.  Only returned if the address is a P2PKH address in the wallet
-| →<br>`account`      | string          | Optional<br>(0 or 1)        | The account this address belong to.  May be an empty string for the default account.  Only returned if the address belongs to the wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "object"
+  p: "Required<br>(exactly 1)"
+  d: "Information about the address"
+
+- n: "→<br>`isvalid`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the address is a valid P2PKH or P2SH address; set to `false` otherwise"
+
+- n: "→<br>`address`"
+  t: "string (base58)"
+  p: "Optional<br>(0 or 1)"
+  d: "If the address is valid, this is the address <!--TODO: figure out in what cases this might be different from the address provided in the parameter -->"
+
+- n: "→<br>`ismine`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if the address belongs to the wallet; set to false if it does not.  Only returned if wallet support enabled"
+
+- n: "→<br>`iswatchonly`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if the address is watch-only.  Otherwise set to `false`.  Only returned if address is in the wallet"
+
+- n: "→<br>`isscript`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if a P2SH address; otherwise set to `false`.  Only returned if the address is in the wallet"
+
+- n: "→<br>`script`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for P2SH addresses belonging to this wallet. This is the type of script:<br>• `pubkey` for a P2PK script inside P2SH<br>• `pubkeyhash` for a P2PKH script inside P2SH<br>• `multisig` for a multisig script inside P2SH<br>• `nonstandard` for unknown scripts"
+
+- n: "→<br>`hex`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for P2SH addresses belonging to this wallet.  This is the redeem script encoded as hex"
+
+- n: "→<br>`addresses`"
+  t: "array"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for P2SH addresses belonging to the wallet.  A P2PKH addresses used in this script, or the computed P2PKH addresses of any pubkeys in this script.  This array will be empty for `nonstandard` script types"
+
+- n: "→ →<br>Address"
+  t: "string"
+  p: "Optional<br>(0 or more)"
+  d: "A P2PKH address"
+
+- n: "→<br>`sigrequired`"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "Only returned for multisig P2SH addresses belonging to the wallet.  The number of signatures required by this script"
+
+- n: "→<br>`pubkey`"
+  t: "string (hex)"
+  p: "Optional<br>(0 or 1)"
+  d: "The public key corresponding to this address.  Only returned if the address is a P2PKH address in the wallet"
+
+- n: "→<br>`iscompressed`"
+  t: "bool"
+  p: "Optional<br>(0 or 1)"
+  d: "Set to `true` if a compressed public key or set to `false` if an uncompressed public key.  Only returned if the address is a P2PKH address in the wallet"
+
+- n: "→<br>`account`"
+  t: "string"
+  p: "Optional<br>(0 or 1)"
+  d: "The account this address belong to.  May be an empty string for the default account.  Only returned if the address belongs to the wallet"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/verifychain.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/verifychain.md
@@ -15,24 +15,33 @@ The `verifychain` RPC {{summary_verifyChain}}
 
 *Parameter #1---how thoroughly to check each block*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Check Level      | number (int)    | Optional<br>(0 or 1)        | How thoroughly to check each block, from 0 to 4.  Default is the level set with the `-checklevel` command line argument; if that isn't set, the default is `3`.  Each higher level includes the tests from the lower levels<br><br>Levels are:<br>**0.** Read from disk to ensure the files are accessible<br>**1.**  Ensure each block is valid<br>**2.** Make sure undo files can be read from disk and are in a valid format<br>**3.** Test each block undo to ensure it results in correct state<br>**4.** After undoing blocks, reconnect them to ensure they reconnect correctly
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Check Level"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "How thoroughly to check each block, from 0 to 4.  Default is the level set with the `-checklevel` command line argument; if that isn't set, the default is `3`.  Each higher level includes the tests from the lower levels<br><br>Levels are:<br>**0.** Read from disk to ensure the files are accessible<br>**1.**  Ensure each block is valid<br>**2.** Make sure undo files can be read from disk and are in a valid format<br>**3.** Test each block undo to ensure it results in correct state<br>**4.** After undoing blocks, reconnect them to ensure they reconnect correctly"
+
+{% enditemplate %}
 
 *Parameter #2---the number of blocks to check*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| Number Of Blocks | number (int)    | Optional<br>(0 or 1)        | The number of blocks to verify.  Set to `0` to check all blocks.  Defaults to the value of the `-checkblocks` command-line argument; if that isn't set, the default is `288`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Number Of Blocks"
+  t: "number (int)"
+  p: "Optional<br>(0 or 1)"
+  d: "The number of blocks to verify.  Set to `0` to check all blocks.  Defaults to the value of the `-checkblocks` command-line argument; if that isn't set, the default is `288`"
+
+{% enditemplate %}
 
 *Result---verification results*
 
-| Name             | Type            | Presence                    | Description
-|------------------|-----------------|-----------------------------|----------------
-| `result`         | bool            | Required<br>(exactly 1)     | Set to `true` if verified; set to `false` if verification failed for any reason
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if verified; set to `false` if verification failed for any reason"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/verifymessage.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/verifymessage.md
@@ -15,31 +15,43 @@ The `verifymessage` RPC {{summary_verifyMessage}}
 
 *Parameter #1---the address corresponding to the signing key*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Address            | string (base58) | Required<br>(exactly 1) | The P2PKH address corresponding to the private key which made the signature.  A P2PKH address is a hash of the public key corresponding to the private key which made the signature.  When the ECDSA signature is checked, up to four possible ECDSA public keys will be reconstructed from from the signature; each key will be hashed and compared against the P2PKH address provided to see if any of them match.  If there are no matches, signature validation will fail
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Address"
+  t: "string (base58)"
+  p: "Required<br>(exactly 1)"
+  d: "The P2PKH address corresponding to the private key which made the signature.  A P2PKH address is a hash of the public key corresponding to the private key which made the signature.  When the ECDSA signature is checked, up to four possible ECDSA public keys will be reconstructed from from the signature; each key will be hashed and compared against the P2PKH address provided to see if any of them match.  If there are no matches, signature validation will fail"
+
+{% enditemplate %}
 
 *Parameter #2---the signature*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Signature          | string (base64) | Required<br>(exactly 1)     | The signature created by the signer encoded as base-64 (the format output by the `signmessage` RPC)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Signature"
+  t: "string (base64)"
+  p: "Required<br>(exactly 1)"
+  d: "The signature created by the signer encoded as base-64 (the format output by the `signmessage` RPC)"
+
+{% enditemplate %}
 
 *Parameter #3---the message*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Message            | string          | Required<br>(exactly 1)     | The message exactly as it was signed (e.g. no extra whitespace)
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Message"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The message exactly as it was signed (e.g. no extra whitespace)"
+
+{% enditemplate %}
 
 *Result: `true`, `false`, or an error*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| `result`           | bool/null       | Required<br>(exactly 1)     | Set to `true` if the message was signed by a key corresponding to the provided P2PKH address; set to `false` if it was not signed by that key; set to JSON `null` if an error occurred
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "bool/null"
+  p: "Required<br>(exactly 1)"
+  d: "Set to `true` if the message was signed by a key corresponding to the provided P2PKH address; set to `false` if it was not signed by that key; set to JSON `null` if an error occurred"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/walletlock.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/walletlock.md
@@ -19,10 +19,13 @@ The `walletlock` RPC {{summary_walletLock}}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | null            | Required<br>(exactly 1)     | Always set to JSON `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always set to JSON `null`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/walletpassphrase.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/walletpassphrase.md
@@ -21,24 +21,33 @@ value of the passphrase parameter).
 
 *Parameter #1---the passphrase*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Passphrase         | string          | Required<br>(exactly 1)     | The passphrase that unlocks the wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Passphrase"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The passphrase that unlocks the wallet"
+
+{% enditemplate %}
 
 *Parameter #2---the number of seconds to leave the wallet unlocked*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Seconds            | number (int)    | Required<br>(exactly 1)     | The number of seconds after which the decryption key will be automatically deleted from memory
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Seconds"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of seconds after which the decryption key will be automatically deleted from memory"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | null            | Required<br>(exactly 1)     | Always set to JSON `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always set to JSON `null`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/walletpassphrasechange.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/walletpassphrasechange.md
@@ -21,24 +21,33 @@ value of the passphrase parameter).
 
 *Parameter #1---the current passphrase*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| Current Passphrase | string          | Required<br>(exactly 1)     | The current wallet passphrase
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "Current Passphrase"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The current wallet passphrase"
+
+{% enditemplate %}
 
 *Parameter #2---the new passphrase*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| New Passphrase     | string          | Required<br>(exactly 1)     | The new passphrase for the wallet
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "New Passphrase"
+  t: "string"
+  p: "Required<br>(exactly 1)"
+  d: "The new passphrase for the wallet"
+
+{% enditemplate %}
 
 *Result---`null` on success*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|---------------
-| `result`           | null            | Required<br>(exactly 1)     | Always set to JSON `null`
-{:.ntpd}
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "null"
+  p: "Required<br>(exactly 1)"
+  d: "Always set to JSON `null`"
+
+{% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*
 

--- a/_plugins/inline-template.rb
+++ b/_plugins/inline-template.rb
@@ -1,0 +1,61 @@
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+## inline-template.rb reformats inline YAML using a template file from
+## the _template directory. (File must end in .inline)
+
+## Example:
+## {% itemplate %}
+## ...YAML...
+## {% enditemplate %}
+
+module Jekyll
+
+require 'yaml'
+
+  class InlineTemplateBlock < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+      @template_name = '_templates/' + text.gsub(' ','') + '.inline'
+    end
+
+    def render(context)
+      output = super
+
+      data = YAML.load(output)
+      template = File.open(@template_name, mode="r")
+      @mytemplate = Liquid::Template.parse(template.read())
+      @mytemplate.render('entry' => data)
+    end
+  end
+end
+
+module Jekyll
+
+require 'yaml'
+
+  class InlineTemplateBlockDisabled < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+    end
+
+    def render(context)
+      output = super
+
+      output
+      #return('Inline Template (itemplate) disabled' + "\n")
+    end
+  end
+end
+
+
+
+#Do nothing if plugin is disabled
+if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('itemplate').nil?
+  print 'Inline Template (itemplate) disabled' + "\n"
+  Liquid::Template.register_tag('itemplate', Jekyll::InlineTemplateBlockDisabled)
+else
+  Liquid::Template.register_tag('itemplate', Jekyll::InlineTemplateBlock)
+end

--- a/_templates/ntpd1.inline
+++ b/_templates/ntpd1.inline
@@ -1,0 +1,4 @@
+| Name                | Type            | Presence                    | Description
+|---------------------|-----------------|-----------------------------|----------------
+{% for item in entry %}| {{item.n}} | {{item.t}} | {{item.p}} | {{item.d}}
+{% endfor %}{:.ntpd}


### PR DESCRIPTION
This pull adds a new plugin that allows converting inline YAML to output formatted by a standard Liquid template.  This pull also reformats the RPC/REST API tables to YAML and then uses a template to create the *exact* same tables as before.  This is verified: diffing the site built on master HEAD against the site built on this final commit shows zero changes.

(No preview provided for the above reason.)

This backend code should make it easier to implement alternative table layouts as discussed in pull #757.

The YAML input for a table looks like this, with n, t, p, and d standing for name, type, presence, and description in the output table.

    {% itemplate ntpd1 %}
    - n: "Keys Or Addresses"
      t: "array"
      p: "Required<br>(exactly 1)"
      d: "An array of strings with each string being a public key or address"

    - n: "→<br>Key Or Address"
      t: "string"
      p: "Required<br>(1 or more)"
      d: "A public key against which signatures will be checked.  Alternatively, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys"
    {% enditemplate %}

The first commit in this pull adds the plugin and the template, and also adds some necessary newlines to the vars.md file.  The second commit just runs the sed script provided in its commit message.