### PR TITLE
Bitcoin for Developers: Change links

### DIFF
--- a/_templates/bitcoin-for-developers.html
+++ b/_templates/bitcoin-for-developers.html
@@ -26,4 +26,5 @@ id: bitcoin-for-developers
 <h2><img class="titleicon" src="/img/icons/ico_micro.svg" alt="Icon" />{% translate micro %}</h2>
 <p>{% translate microtext %}</p>
 
-<div class="mainbutton"><a href="/en/developer-documentation"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
+<div class="introlink"><a href="https://bitcoin.org/en/developer-documentation">Developer Documentation {% if page.lang != "en" %}(English){% endif %}</a></div>
+<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>


### PR DESCRIPTION
I find misleading that the [Bitcoin for Developers](https://bitcoin.org/en/bitcoin-for-developers) page has the same "Get started with Bitcoin" button as the other pages but with a different link (english only, even if the button is translated).
I propose:
   1. Restore the same link for the button as the other pages ([Getting started](https://bitcoin.org/en/getting-started)).
   2. Add a Developer Documentation link without translating: I think this is not a problem / more indicative because the documentation is English only.