### PR TITLE
Backend: Test That Site Builds With Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - "2.0.0"
+
+script: make all
+
+notifications:
+  email:
+    recipients:
+      - dave@dtrt.org

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status](https://travis-ci.org/bitcoin/bitcoin.org.svg?branch=master)
+
 ## How To Participate
 
 *Bitcoin.org needs volunteers like you!*  Here are some ways you can help:
@@ -85,6 +87,35 @@ git remote add upstream https://github.com/bitcoin/bitcoin.org.git
 7. Click on your branch on GitHub and click the **Compare / pull request** button to send a pull request.
 
 When submitting a pull request, please take required time to discuss your changes and adapt your work. It is generally a good practice to split unrelated changes into separate branchs and pull requests.
+
+**Travis Continuous Integration (CI)**
+
+Shortly after your Pull Request (PR) is submitted, a Travis CI job will
+be added to [our queue](https://travis-ci.org/harding/bitcoin.org). This
+will build the site and run some basic checks. If the job fails, you
+will be emailed a link to the build log and the PR will indicate a
+failed job. Read the build report and try to correct the problem---but
+if you feel confused or frustrated, please ask for help on the PR (we're
+always happy to help).
+
+If you don't want a particular commit to be tested, add `[ci skip]`
+anywhere in its commit message.
+
+If you'd like to setup Travis on your own repository so you can test
+builds before opening a pull request, it's really simple:
+
+1. Make sure the master branch of your repository is up to date with the
+   bitcoin/bitcoin.org master branch.
+
+2. Open [this guide](http://docs.travis-ci.com/user/getting-started/)
+   and perform steps one, two, and four. (The other steps are already
+   done in our master branch.)
+
+3. After you push a branch to your repository, go to your branches page
+   (e.g. for user harding, github.com/harding/bitcoin.org/branches). A
+   yellow circle, green checkmark, or red X will appear near the branch
+   name when the build finishes, and clicking on the icon will take you
+   to the corresponding build report.
 
 **How to make additional changes in a pull request**
 

--- a/_config.yml
+++ b/_config.yml
@@ -153,6 +153,7 @@ exclude:
     - Gemfile
     - Gemfile.lock
     - Makefile
+    - vendor  # Travis CI creates a vendor/ dir with files we shouldn't render
 
 future:      true
 lsi:         false


### PR DESCRIPTION
This pull adds a control file for automatically test building the site in Travis CI.  The pull also adds documentation and makes one minor change to the _config.yml file to prevent conflicting with Travis.

In addition to merging this pull, a Travis webhook needs to be installed.  One of the core devs has already given Travis permission to toggle that hook, and I have sufficient permissions to tell Travis to enable it---so if this PR is ACKed, I will enable it before merging.

Once everything is enabled, all bitcoin/bitcoin.org branches will be test built and all PRs against bitcoin/bitcoin.org branches will also be test built.  A message will be left on the PRs indicating whether or not they passed the test build and an icon at the top of our README.md will indicate the status of the master branch.

### Preview

I've enabled this on my own fork of Bitcoin.org.  You can see my build logs [here](https://travis-ci.org/harding/bitcoin.org).

You can test pull request building by creating a broken (or working) commit and opening a pull request for it to my master branch: `https://github.com/harding/bitcoin.org`

(Do whatever you want, just do me the favor of closing the PR when you're done testing.)

### Notifications

By default, Travis docs say it notifies all organization members about failed builds.  Since I don't want to spam the core devs, I've configured it to just email me.  If anyone else wants to me emailed, leave a comment below before this gets merged and I'll add you.  (Afterwards, just open a PR adding your email to the .travis.yml file.)

### Interference With Core Development?

@theuni Please let me know if our using Travis in any way interferes with core development since we're part of the same GitHub organization.

Everyone else: Based on some quick responses I received in #bitcoin-dev, the main downside seems to be that travis-ci.org (the free version of Travis we're using) is limited to 5 concurrent builds from the same organization. When I configure Travis for Bitcoin.org, I'll set the maximum number of concurrent builds we use to one, so for the approximately 8 minutes it takes to build the site, we could (at worst) be holding up one Bitcoin Core PR.

Since we only handle a small number of PRs a day, I don't think this should be an issue, but opinions from core devs are welcome.

In addition, if the core team decides to use the paid version of Travis, someone should email me or @saivann. We'd have to discuss the actual amount, but we do have a small budget to pay our fair share.