### PR TITLE
Releases: Add Bitcoin Core 0.10.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,8 @@ manual-check-diff-sha256sums:
 	  | sort -k2
 
 check-for-broken-bitcoin-core-download-links:
+## Ensure that the links from the Download page to the current Bitcoin
+## Core binaries are correct
 	$S grep 'class="dl"' _site/en/download.html \
 	  | sed 's/.*href="//; s/".*//' \
 	  | while read url ; do \

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Download links will automatically be set to the defaults using the current
 release version number, but if you need to change any download URL, edit
 the file `_templates/download.html`
 
-[Once Travis is enabled] You can then create a pull request to the
+You can then create a pull request to the
 master branch and Travis CI will automatically build it and make sure
 the links you provided return a "200 OK" HTTP header. (The actual files
 will not be downloaded to save bandwidth.) Alternatively, you can build
@@ -444,6 +444,88 @@ the site locally with `make all` to run the same quality assurance tests.
 
 The file can be edited later to add any optional information (such as a
 release date) that you didn't have when you created the file.
+
+#### Preparing a release in advance
+
+It's nice to prepare a release pull request in advance so that the
+Bitcoin Core developers can just click "Merge Pull Request" when the new
+version is released.  Here's the recommended recipe, where `<VERSION>`
+is the particular version:
+
+1. Create a new branch named `bitcoin-core-<VERSION>`.  You can either
+   do this locally or in GitHub's web GUI.
+
+2. Follow the instructions in the [Release Notes][] section to create a
+   new release.  You should leave the `optional_date` blank unless you
+   happen to know the date of the planned release.
+
+3. Push the branch to the https://github.com/bitcoin/bitcoin.org
+   repository so any contributor can edit it. **Don't** open a pull
+   request yet.
+
+4. Travis CI will build the site from the branch and then run the tests.
+   The tests will fail because they expect the release binaries to be
+   present and you're preparing this release request in advance of them
+   being uploaded.
+
+5. Open the failed Travis CI log.  At the end, it will say something like:
+
+        ERROR:
+        Error: Could not retrieve /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64-setup.exe
+        Error: Could not retrieve /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32-setup.exe
+        [...]
+
+6. Copy the errors from above into a text file and remove everything
+   except for the URLs so that what's left are lines that look like:
+
+        /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64-setup.exe
+        /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32-setup.exe
+        [...]
+
+7. Optional, but nice: sort the lines into alphabetical order.
+
+8. Now open a pull request from the `bitcoin-core-<VERSION>` branch to
+   the `master` branch. We recommend that you use this title: "Releases:
+   Add Bitcoin Core &lt;VERSION>".
+
+   We recommend that you use the following text with any changes you
+   think are appropriate. **Note:** read all the way to the end of this
+   enumerated point before submitting your pull request.
+
+        This updates the download links to point to <VERSION> and adds the
+        <VERSION> release notes to the site. I'll keep it updated throughout
+        the RC cycle, but it can be merged by anyone with commit access
+        once <VERSION> final is released (see TODO lists below).
+
+        CC: @laanwj
+
+        Essential TODO:
+
+        * [ ] Make sure the download links work. This is automatically checked as part of the Travis CI build, so trigger a rebuild and, if it passes, this should be safe to merge.
+
+        Optional TODO (may be done in commits after merge):
+
+        * [ ] Add the actual release date to the YAML header in `_releases/0.10.1.md`
+        * [ ] Add the magnet URI to the YAML header in `_releases/0.10.1.md` (brief instructions for creating the link are provided as comments in that file)
+
+        Expected URLs for the Bitcoin Core binaries:
+
+    Underneath the line 'Expected URLs', paste the URLs you retrieved
+    from Travis CI earlier.
+
+    Note that @laanwj is Wladimir J. van der Laan, who is usually
+    responsible for uploading the Bitcoin Core binaries.  If someone
+    else is responsible for this release, CC them instead.  If you don't
+    know who is responsible, ask in #bitcoin-dev on Freenode.
+
+9. After creating the pull request, use the Labels menu to assign it the
+   "Releases" label. This is important because it's what the Bitcoin
+   Core release manager will be looking for.
+
+10. After each new Release Candidate (RC) is released, update the
+    release notes you created in the `_releases` directory. (But don't
+    worry about this too much; we can always upload updated release
+    notes after the release.)
 
 ### Alerts
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -102,7 +102,10 @@
     <div class="footerlicense">© Bitcoin Project 2009-{{ site.time | date: '%Y' }} {% translate footer layout %}</div>
     </div>
   </div>
-  <script type="text/javascript">fallbackSVG();</script>
+  <script type="text/javascript">
+    fallbackSVG();
+    addAnchorLinks();
+  </script>
 </body>
 
 </html>

--- a/_releases/0.10.1.md
+++ b/_releases/0.10.1.md
@@ -84,6 +84,7 @@ behavior, not code moves, refactors or string updates.
 RPC:
 
 - `7f502be` fix crash: createmultisig and addmultisigaddress
+- `eae305f` Fix missing lock in submitblock
 
 Block (database) and transaction handling:
 
@@ -92,6 +93,8 @@ Block (database) and transaction handling:
 - `002c8a2` fix possible block db breakage during re-index
 - `a1f425b` Add (optional) consistency check for the block chain data structures
 - `1c62e84` Keep mempool consistent during block-reorgs
+- `57d1f46` Fix CheckBlockIndex for reindex
+- `bac6fca` Set nSequenceId when a block is fully linked
 
 P2P protocol and network code:
 
@@ -104,6 +107,7 @@ P2P protocol and network code:
 - `0c6f334` Always use a 50% chance to choose between tried and new entries (countermeasure 2 against eclipse attacks)
 - `214154e` Do not bias outgoing connections towards fresh addresses (countermeasure 2 against eclipse attacks)
 - `aa587d4` Scale up addrman (countermeasure 6 against eclipse attacks)
+- `139cd81` Cap nAttempts penalty at 8 and switch to pow instead of a division loop
 
 Validation:
 
@@ -131,6 +135,9 @@ Miscellaneous:
 
 - `c9e022b` Initialization: set Boost path locale in main thread
 - `23126a0` Sanitize command strings before logging them.
+- `323de27` Initialization: setup environment before starting QT tests
+- `7494e09` Initialization: setup environment before starting tests
+- `df45564` Initialization: set fallback locale as environment variable
 
 Credits
 =======
@@ -146,6 +153,8 @@ Thanks to everyone who contributed to this release:
 - Ivan Pustogarov
 - Jonas Nick
 - Jonas Schnelli
+- Matt Corallo
+- mrbandrews
 - Pieter Wuille
 - Ruben de Vries
 - Suhas Daftuar

--- a/_releases/0.10.1.md
+++ b/_releases/0.10.1.md
@@ -1,0 +1,154 @@
+---
+## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
+required_version: 0.10.1
+## Optional release date.  May be filled in hours/days after a release
+optional_date:
+## Optional title.  If not set, default is: Bitcoin Core version %v released
+optional_title: Bitcoin Core version %v released
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+## The --- below ends the YAML header. After that, paste the release notes.
+## Warning: this site's Markdown parser commonly requires you make two
+## changes to the release notes from the Bitcoin Core source tree:
+##
+## 1. Make sure both ordered and unordered lists are preceeded by an empty
+## (whitespace only) line, like the empty line before this list item.
+##
+## 2. Place URLs inside angle brackets, like <http://bitcoin.org/bin>
+
+---
+Bitcoin Core version 0.10.1 is now available from:
+
+  <https://bitcoin.org/bin/bitcoin-core-0.10.1/>
+
+This is a new minor version release, bringing bug fixes and translation
+updates. If you are using 0.10.0, it is recommended to upgrade to this
+version.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+Upgrading and downgrading
+=========================
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
+
+Downgrade warning
+------------------
+
+Because release 0.10.0 and later makes use of headers-first synchronization and
+parallel block download (see further), the block files and databases are not
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
+
+* Blocks will be stored on disk out of order (in the order they are
+received, really), which makes it incompatible with some tools or
+other programs. Reindexing using earlier versions will also not work
+anymore as a result of this.
+
+* The block index database will now hold headers for which no block is
+stored on disk, which earlier versions won't support.
+
+If you want to be able to downgrade smoothly, make a backup of your entire data
+directory. Without this your node will need start syncing (or importing from
+bootstrap.dat) anew afterwards. It is possible that the data from a completely
+synchronised 0.10 node may be usable in older versions as-is, but this is not
+supported and may break as soon as the older version attempts to reindex.
+
+This does not affect wallet forward or backward compatibility.
+
+Notable changes
+===============
+
+This is a minor release and hence there are no notable changes.
+For the notable changes in 0.10, refer to the release notes for the
+0.10.0 release at <https://github.com/bitcoin/bitcoin/blob/v0.10.0/doc/release-notes.md>
+
+0.10.1 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect external
+behavior, not code moves, refactors or string updates.
+
+RPC:
+
+- `7f502be` fix crash: createmultisig and addmultisigaddress
+
+Block (database) and transaction handling:
+
+- `1d2cdd2` Fix InvalidateBlock to add chainActive.Tip to setBlockIndexCandidates
+- `c91c660` fix InvalidateBlock to repopulate setBlockIndexCandidates
+- `002c8a2` fix possible block db breakage during re-index
+- `a1f425b` Add (optional) consistency check for the block chain data structures
+- `1c62e84` Keep mempool consistent during block-reorgs
+
+P2P protocol and network code:
+
+- `78f64ef` don't trickle for whitelisted nodes
+- `ca301bf` Reduce fingerprinting through timestamps in 'addr' messages.
+- `200f293` Ignore getaddr messages on Outbound connections.
+- `d5d8998` Limit message sizes before transfer
+- `aeb9279` Better fingerprinting protection for non-main-chain getdatas.
+- `cf0218f` Make addrman's bucket placement deterministic (countermeasure 1 against eclipse attacks, see http://cs-people.bu.edu/heilman/eclipse/)
+- `0c6f334` Always use a 50% chance to choose between tried and new entries (countermeasure 2 against eclipse attacks)
+- `214154e` Do not bias outgoing connections towards fresh addresses (countermeasure 2 against eclipse attacks)
+- `aa587d4` Scale up addrman (countermeasure 6 against eclipse attacks)
+
+Validation:
+
+- `d148f62` Acquire CCheckQueue's lock to avoid race condition
+
+Build system:
+
+- `8752b5c` 0.10 fix for crashes on OSX 10.6
+
+Wallet:
+
+- N/A
+
+GUI:
+
+- `2c08406` some mac specifiy cleanup (memory handling, unnecessary code)
+- `81145a6` fix OSX dock icon window reopening
+- `786cf72` fix a issue where "command line options"-action overwrite "Preference"-action (on OSX)
+
+Tests:
+
+- `1117378` add RPC test for InvalidateBlock
+
+Miscellaneous:
+
+- `c9e022b` Initialization: set Boost path locale in main thread
+- `23126a0` Sanitize command strings before logging them.
+
+Credits
+=======
+
+Thanks to everyone who contributed to this release:
+
+- Alex Morcos
+- Cory Fields
+- dexX7
+- fsb4000
+- Gavin Andresen
+- Gregory Maxwell
+- Ivan Pustogarov
+- Jonas Nick
+- Jonas Schnelli
+- Pieter Wuille
+- Ruben de Vries
+- Suhas Daftuar
+- Wladimir J. van der Laan
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/_templates/faq.html
+++ b/_templates/faq.html
@@ -279,5 +279,3 @@ id: faq
 
 <h3 id="{% translate morehelp anchor.faq %}">{% translate morehelp %}</h3>
 <p>{% translate morehelptxt1 %}</p>
-
-<script>addAnchorLinks();</script>

--- a/_templates/vocabulary.html
+++ b/_templates/vocabulary.html
@@ -37,5 +37,3 @@ voc:
 <h2 id="{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</h2>
 <p>{% translate {{v}}txt %}</p>
 {% endalphab_for %}
-
-<script>addAnchorLinks();</script>

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1035,4 +1035,3 @@ instructions, please [open an issue.](https://github.com/bitcoin/bitcoin.org/iss
 
 </div>
 <script>updateToc();</script>
-<script>addAnchorLinks();</script>

--- a/js/base.js
+++ b/js/base.js
@@ -89,7 +89,6 @@ var mm = document.getElementById('menusimple');
 var ml = document.getElementById('langselect');
 var t = document.getElementById('menumobile');
 mm.style.display = ml.style.display = (mm.style.display == 'block') ? '' : 'block';
-t.parentNode.removeChild(t);
 cancelEvent(e);
 }
 

--- a/js/base.js
+++ b/js/base.js
@@ -110,3 +110,20 @@ setTimeout(function() {
 	}
 }, 1);
 }
+
+function addAnchorLinks() {
+// Apply anchor links icon on each title displayed on CSS hover.
+var nodes = [];
+var tags = ['H2', 'H3', 'H4', 'H5', 'H6'];
+for (var i = 0, n = tags.length; i < n; i++) {
+	for (var ii = 0, t = document.getElementsByTagName(tags[i]), nn = t.length; ii < nn; ii++) nodes.push(t[ii]);
+}
+for (var i = 0, n = nodes.length; i < n; i++) {
+	if (!nodes[i].id) continue;
+	if (nodes[i].getElementsByTagName('A').length > 0 && nodes[i].getElementsByTagName('A')[0].innerHTML == '') return;
+	addClass(nodes[i], 'anchorAf');
+	var anc = document.createElement('A');
+	anc.href = '#' + nodes[i].id;
+	nodes[i].insertBefore(anc, nodes[i].firstChild);
+}
+}

--- a/js/main.js
+++ b/js/main.js
@@ -297,23 +297,6 @@ addEvent(window, 'load', evtimestamp);
 init();
 }
 
-function addAnchorLinks() {
-// Apply anchor links icon on each title displayed on CSS hover.
-var nodes = [];
-var tags = ['H2', 'H3', 'H4', 'H5', 'H6'];
-for (var i = 0, n = tags.length; i < n; i++) {
-	for (var ii = 0, t = document.getElementsByTagName(tags[i]), nn = t.length; ii < nn; ii++) nodes.push(t[ii]);
-}
-for (var i = 0, n = nodes.length; i < n; i++) {
-	if (!nodes[i].id) continue;
-	if (nodes[i].getElementsByTagName('A').length > 0 && nodes[i].getElementsByTagName('A')[0].innerHTML == '') return;
-	addClass(nodes[i], 'anchorAf');
-	var anc = document.createElement('A');
-	anc.href = '#' + nodes[i].id;
-	nodes[i].insertBefore(anc, nodes[i].firstChild);
-}
-}
-
 function updateIssue(e) {
 // Update GitHub issue link pre-filled with current page location.
 var t = getEventTarget(e);


### PR DESCRIPTION
Preview: http://dg4.dtrt.org/en/download and http://dg4.dtrt.org/en/release/v0.10.1

This updates the download links to point to 0.10.1 and adds the 0.10.1RC3 release notes to the site.  I'll keep it updated througout the RC cycle, but it can be merged by anyone with commit access once 0.10.1 final is released (see TODO lists below).

CC: @laanwj

Essential TODO:

* [X] Figure out where the files go as discussed in #748 (discussed: it should be https://bitcoin.org/bin/bitcoin-core-0.10.1/)
* [ ] Make sure the download links work.  This is now automatically checked as part of the Travis CI build, so trigger a rebuild and, if it passes, this should be safe to merge.


Optional TODO (may be done in commits after merge):

* [ ] Add the actual release date to the YAML header in `_releases/0.10.1.md`
* [ ] Add the magnet URI to the YAML header in `_releases/0.10.1.md` (brief instructions for creating the link are provided as comments in that file)

Expected URLs for the binaries and torrent are:

    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-linux32.tar.gz
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-linux64.tar.gz
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-osx64.tar.gz
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-osx.dmg
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1.tar.gz
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1.torrent
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32-setup.exe
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32.zip
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64-setup.exe
    /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64.zip
    /bin/bitcoin-core-0.10.1/SHA256SUMS.asc

(Torrent should be created automatically within 5 minutes of files being uploaded.)

(Travis rebuild instructions, in case anyone needs them: at the bottom of this PR where it says Travis failed, click "Details" to go to the failed build on Travis.org; on the right side on the screen beneath the Settings button, click the semicircle-arrow icon to rebuild.)