### PR TITLE
Don't remove mobile menu on click

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -89,7 +89,6 @@ var mm = document.getElementById('menusimple');
 var ml = document.getElementById('langselect');
 var t = document.getElementById('menumobile');
 mm.style.display = ml.style.display = (mm.style.display == 'block') ? '' : 'block';
-t.parentNode.removeChild(t);
 cancelEvent(e);
 }
 


### PR DESCRIPTION
On mobile, or small viewports, the dropdown menu button is removed on click. It seems like it was intentional, but _to me_ it seems a bit weird and non-standard. Is there any particular reason it works that way? I'm I missing something? 

## Screenshot - Expanded menu

![bitcoin-expanded-mobile-nav](https://cloud.githubusercontent.com/assets/922411/7020023/08c837aa-dd16-11e4-8915-e24d52ba709b.png)
