### PR TITLE
Missing address for events causes build script to fail

### DIFF
--- a/_plugins/events.rb
+++ b/_plugins/events.rb
@@ -103,7 +103,8 @@ module Jekyll
         # Get geolocalisation data from Google Maps
         if data.has_key?('address')
           begin
-            geoloc = JSON.parse(open("https://maps.googleapis.com/maps/api/geocode/json?address=" + CGI::escape(data['address'] + ', ' + data['city'] + ', ' + data['country']) + "&sensor=false","User-Agent"=>"Ruby/#{RUBY_VERSION}").read)
+            address = [data['address'], data['city'], data['country']].reject(&:nil?).join(', ')
+            geoloc = JSON.parse(open("https://maps.googleapis.com/maps/api/geocode/json?address=" + CGI::escape(address) + "&sensor=false","User-Agent"=>"Ruby/#{RUBY_VERSION}").read)
             if geoloc['status'] == 'OK'
               data['geoloc'] = geoloc['results'][0]['geometry']['location']['lat'].to_s + ", " + geoloc['results'][0]['geometry']['location']['lng'].to_s
             end


### PR DESCRIPTION
[_events.yml:L76-79](https://github.com/bitcoin/bitcoin.org/blob/master/_events.yml#L73-79) 
```YAML
- date: 2015-05-02
  title: "WeBTCExpo"
  venue:
  address:
  city: "Amsterdam"
  country: "Netherlands"
  link: "http://webtcexpo.com/"
```
does not define any address and raises an error on this line: [events.rb#L106](https://github.com/bitcoin/bitcoin.org/blob/master/_plugins/events.rb#L106)

```ruby
# In the middle of line 106:
data['address']  # => nil
# And therefore
data['address'] + ',' # => undefined method `+' for nil:NilClass
```

I think the simplest solution would to be to make the address optional and let google place a generic pin based of `data['city']`, `data['country']` therefore this PR.

What do you think? :eyes: 