### PR TITLE
Fixes the position of the nav icon when resizeing the window on Chrome

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -40,8 +40,8 @@
       </ul>
       </li>
     </ul>
-    <a class="logo" href="/{{ page.lang }}/"><img src="/img/icons/logotop.svg" alt="Bitcoin"></a>
     <a id="menumobile" class="menumobile" onclick="mobileMenuShow(event);" href="#"></a>
+    <a class="logo" href="/{{ page.lang }}/"><img src="/img/icons/logotop.svg" alt="Bitcoin"></a>
     <div id="langselect" class="langselect"><select onchange="window.location=this.value;">
     {% for lang in site.langsorder %}{% assign active = ''%}{% if lang == page.lang %}{% assign active = ' selected="selected"'%}{% endif %}
           <option value="/{{ lang }}/{% translate {{page.id}} url {{lang}} %}"{{ active }}>{{ site.langs[lang] }}</option>


### PR DESCRIPTION
This fixes #808 for some reason, must be a bug in chrome.. Tested the change on safari and firefox and then still render it fine. I'm a bit frustrated that I have no clue why this fixes the issue in chrome :)

@saivann 