### PR TITLE
Stylefix on dev docs page

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1098,6 +1098,7 @@ table td,table th{
 .resources .resourcesext{
 	margin-top:5px;
 	min-height:0;
+	display: inline-block;
 }
 .resources .resourcesext p{
 	padding-left:24px;


### PR DESCRIPTION
https://bitcoin.org/en/developer-documentation the links with icons looks broken on tablets/large phones.

### Before

![brokenstyle](https://cloud.githubusercontent.com/assets/922411/7032981/efe8bc76-dd76-11e4-83bb-6c1e60114d3b.png)

### After

![displayinline](https://cloud.githubusercontent.com/assets/922411/7032982/f16548a8-dd76-11e4-92d3-33f33f270916.png)
