### PR TITLE
Layout: Add anchor link affordance to all pages

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -106,7 +106,10 @@
     <div class="footerlicense">© Bitcoin Project 2009-{{ site.time | date: '%Y' }} {% translate footer layout %}</div>
     </div>
   </div>
-  <script type="text/javascript">fallbackSVG();</script>
+  <script type="text/javascript">
+    fallbackSVG();
+    addAnchorLinks();
+  </script>
 </body>
 
 </html>

--- a/_templates/faq.html
+++ b/_templates/faq.html
@@ -279,5 +279,3 @@ id: faq
 
 <h3 id="{% translate morehelp anchor.faq %}">{% translate morehelp %}</h3>
 <p>{% translate morehelptxt1 %}</p>
-
-<script>addAnchorLinks();</script>

--- a/_templates/vocabulary.html
+++ b/_templates/vocabulary.html
@@ -37,5 +37,3 @@ voc:
 <h2 id="{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</h2>
 <p>{% translate {{v}}txt %}</p>
 {% endalphab_for %}
-
-<script>addAnchorLinks();</script>

--- a/en/developer-examples.md
+++ b/en/developer-examples.md
@@ -41,4 +41,3 @@ title: "Developer Examples - Bitcoin"
 </div>
 
 <script>updateToc();</script>
-<script>addAnchorLinks();</script>

--- a/en/developer-guide.md
+++ b/en/developer-guide.md
@@ -54,4 +54,3 @@ of the following file. -->
 </div>
 
 <script>updateToc();</script>
-<script>addAnchorLinks();</script>

--- a/en/developer-reference.md
+++ b/en/developer-reference.md
@@ -245,4 +245,3 @@ untrusted source.
 </div>
 
 <script>updateToc();</script>
-<script>addAnchorLinks();</script>

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1035,4 +1035,3 @@ instructions, please [open an issue.](https://github.com/bitcoin/bitcoin.org/iss
 
 </div>
 <script>updateToc();</script>
-<script>addAnchorLinks();</script>

--- a/js/base.js
+++ b/js/base.js
@@ -110,3 +110,20 @@ setTimeout(function() {
 	}
 }, 1);
 }
+
+function addAnchorLinks() {
+// Apply anchor links icon on each title displayed on CSS hover.
+var nodes = [];
+var tags = ['H2', 'H3', 'H4', 'H5', 'H6'];
+for (var i = 0, n = tags.length; i < n; i++) {
+	for (var ii = 0, t = document.getElementsByTagName(tags[i]), nn = t.length; ii < nn; ii++) nodes.push(t[ii]);
+}
+for (var i = 0, n = nodes.length; i < n; i++) {
+	if (!nodes[i].id) continue;
+	if (nodes[i].getElementsByTagName('A').length > 0 && nodes[i].getElementsByTagName('A')[0].innerHTML == '') return;
+	addClass(nodes[i], 'anchorAf');
+	var anc = document.createElement('A');
+	anc.href = '#' + nodes[i].id;
+	nodes[i].insertBefore(anc, nodes[i].firstChild);
+}
+}

--- a/js/main.js
+++ b/js/main.js
@@ -297,23 +297,6 @@ addEvent(window, 'load', evtimestamp);
 init();
 }
 
-function addAnchorLinks() {
-// Apply anchor links icon on each title displayed on CSS hover.
-var nodes = [];
-var tags = ['H2', 'H3', 'H4', 'H5', 'H6'];
-for (var i = 0, n = tags.length; i < n; i++) {
-	for (var ii = 0, t = document.getElementsByTagName(tags[i]), nn = t.length; ii < nn; ii++) nodes.push(t[ii]);
-}
-for (var i = 0, n = nodes.length; i < n; i++) {
-	if (!nodes[i].id) continue;
-	if (nodes[i].getElementsByTagName('A').length > 0 && nodes[i].getElementsByTagName('A')[0].innerHTML == '') return;
-	addClass(nodes[i], 'anchorAf');
-	var anc = document.createElement('A');
-	anc.href = '#' + nodes[i].id;
-	nodes[i].insertBefore(anc, nodes[i].firstChild);
-}
-}
-
 function updateIssue(e) {
 // Update GitHub issue link pre-filled with current page location.
 var t = getEventTarget(e);


### PR DESCRIPTION
This pull calls a Javascript function to display a hyperlinked icon whenever a Javascript-enabled user hovers on any subhead on the site that has an anchor set.  Combined with PR #813, it makes it easy for users to link to any section within the site.

This pull request is being added to the bitcoin-core-0.10.1 branch because updating the Javascript will trigger an alert to people monitoring the page.  Since that alert will be triggered when 0.10.1 is released, this will avoid an unnecessary extra alert.

Live preview of this PR plus PR #813 merged together: http://dg1.dtrt.org/en/bitcoin-for-individuals

Screenshots of the anchor link icon in different layouts:

![2015-04-09-112414_1280x800_scrot](https://cloud.githubusercontent.com/assets/61096/7070841/8c1ed182-deaf-11e4-8f49-8c1f9a4a93c7.png)

![2015-04-09-112425_1280x800_scrot](https://cloud.githubusercontent.com/assets/61096/7070846/933023b8-deaf-11e4-843e-b71bf362240f.png)

Note: this branch will fail Travis CI because its based on the 0.10.1 branch that itself fails until 0.10.1 final is uploaded to the site.