### PR TITLE
Expend the "Participate" menu entry

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -63,13 +63,18 @@
           <li{% if page.id == 'resources' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate resources url %}">{% translate menu-resources layout %}</a></li>
           <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
           {% if page.lang == 'en' %}<li{% if page.id == 'developer-documentation' %} class="active"{% endif %}><a href="/en/developer-documentation">Documentation</a></li>{% endif %}
-          <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
           <li{% if page.id == 'vocabulary' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate vocabulary url %}">{% translate menu-vocabulary layout %}</a></li>
           <li{% if page.id == 'events' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate events url %}">{% translate menu-events layout %}</a></li>
         </ul>
       </li>
       <li{% if page.id == 'innovation' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate innovation url %}">{% translate menu-innovation layout %}</a></li>
-      <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a></li>
+      <li><a href="#" onclick="return false;">{% translate menu-participate layout %}</a>
+        <ul>
+          <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a>
+          {% if page.lang == 'en' %}<li{% if page.id == 'full-node' %} class="active"{% endif %}><a href="/en/full-node">Running a full node</a></li>{% endif %}
+          <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
+        </ul>
+      </li>
       {% case page.lang %}
       {% when 'sv' %}
       {% else %}

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -289,7 +289,8 @@ table td,table th{
 	border-radius:5px;
 }
 .menusimple li:first-child,
-.menusimple li:first-child+li{
+.menusimple li:first-child+li,
+.menusimple li:first-child+li+li+li{
 	-webkit-border-bottom-left-radius:0;
 	-webkit-border-bottom-right-radius:0;
 	-moz-border-radius-bottomleft:0;

--- a/_translations/ar.yml
+++ b/_translations/ar.yml
@@ -624,6 +624,7 @@ ar:
     tax: "الضرائب الحكومية والقوانين"
     taxtxt: "البت كوين هي عملة غير رسمية. ومع هذا، فبعض السلطات لا تزال تطالبك بدفع ضرائب دخل، ضرائب مبيعات، ضرائب على المرتبات، ضرائب على الممتلكات والأرباح الرأسمالية عن كل شئ ذو قيمة، متضمناً ذلك البت كوين. إنها مسئوليتك الشخصية أن تتأكد من الوفاء بإلتزامات <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">الضرائب و المستحقات القانونية أو التنظيمية</a> أو إلتزاماتك المطلوبة منك من قبل حكومتك و/أو السلطات المحلية حيث تقطن."
   layout:
+    menu-support-bitcoin: "دعم البت كوين"
     menu-about-us: "حول موقع bitcoin.org"
     menu-bitcoin-for-businesses: الأعمال
     menu-bitcoin-for-developers: المطورين
@@ -639,7 +640,7 @@ ar:
     menu-legal: "المسائل القانونية"
     menu-press: "صحافة"
     menu-resources: المصادر
-    menu-support-bitcoin: المشاركة
+    menu-participate: المشاركة
     menu-vocabulary: المفردات
     menu-you-need-to-know: "يجب عليك معرفة"
     banner-translate: "الترجمة لهذه اللغة قديمة. </a> إضغط هنا لتساعد في ترجمة موقع bitcoin.org بلغتك<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">."

--- a/_translations/bg.yml
+++ b/_translations/bg.yml
@@ -626,6 +626,7 @@ bg:
     tax: "Правителствени данъци и регулации"
     taxtxt: "Биткойн не е официална валута. Повечето юрисдикции все още изискват от вас да платите данъци върху доходите, продажбите, заплатите и капиталовите печалби на всичко, което има стойност, включително биткойни. Ваша е отговорността да се гарантира, че се придържате към <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">данъчните и други законови или подзаконови разпоредби</a> издадени от вашето правителство и/или местните общини."
   layout:
+    menu-support-bitcoin: "Допринесете към Биткойн"
     menu-about-us: "Относно bitcoin.org"
     menu-bitcoin-for-businesses: Фирми
     menu-bitcoin-for-developers: Разработчици
@@ -643,7 +644,7 @@ bg:
     menu-privacy: "Защита на личните данни"
     menu-resources: Ресурси
     menu-stats: "Статистики"
-    menu-support-bitcoin: Участвайте
+    menu-participate: Участвайте
     menu-vocabulary: Речник
     menu-you-need-to-know: "Трябва да знаете"
     banner-translate: "Преводите за този език са остарели. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Натиснете тук, за да помогнете с превода на bitcoin.org на вашия език</a>."

--- a/_translations/da.yml
+++ b/_translations/da.yml
@@ -665,6 +665,7 @@ da:
     tax: "Staters beskatninger og reguleringer"
     taxtxt: "Bitcoin er ikke en officiel valuta. Når der er sagt, kræver de fleste myndigheder, at du betaler indkomstskat, moms, arbejdsgiverskat og kapitalindkomstskat af alt, hvad der har værdi, inklusive bitcoin. Det er dit ansvar at sikre dig, at du retter dig efter <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">skatter og andre lovformelige eller regulative mandater</a>, der er udstedt af din regering og/eller kommune."
   layout:
+    menu-support-bitcoin: "Støt Bitcoin"
     menu-about-us: "Om bitcoin.org"
     menu-bitcoin-for-businesses: Virksomheder
     menu-bitcoin-for-developers: Udviklere
@@ -682,7 +683,7 @@ da:
     menu-privacy: "Privatliv"
     menu-resources: Ressourcer
     menu-stats: "Statistik"
-    menu-support-bitcoin: Deltag
+    menu-participate: Deltag
     menu-vocabulary: Ordliste
     menu-you-need-to-know: "Du bør vide"
     banner-translate: "Oversættelsen til dette sprog er uddateret. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Klik her for at hjælpe med at oversætte bitcoin.org til dit sprog</a>."

--- a/_translations/de.yml
+++ b/_translations/de.yml
@@ -659,6 +659,7 @@ de:
     tax: "Steuern und Regulierung"
     taxtxt: "Bitcoin ist keine offizielle Währung. Allerdings sehen die meisten Gesetzgeber immer noch Einkommens-, Umsatz- und Lohnsteuer, sowie Kapitalertragssteuern auf alle Anlagen, inklusive Bitcoin, vor. Es liegt in Ihrer Verantwortung sicherzustellen, dass Sie <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">eventuell erforderliche Steuern bezahlen</a> und andere von Ihrer Regierung und/oder Gemeinde beschlossenen rechtlichen oder regulatorischen Erlässe einhalten."
   layout:
+    menu-support-bitcoin: "Bitcoin unterstützen"
     menu-about-us: "Über bitcoin.org"
     menu-bitcoin-for-businesses: Unternehmen
     menu-bitcoin-for-developers: Entwickler
@@ -676,7 +677,7 @@ de:
     menu-privacy: "Privatsphäre"
     menu-resources: Ressourcen
     menu-stats: "Statistiken"
-    menu-support-bitcoin: Mitmachen
+    menu-participate: Mitmachen
     menu-vocabulary: Glossar
     menu-you-need-to-know: "Das sollten Sie wissen"
     banner-translate: "Übersetzungen für diese Sprache sind veraltet. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Klicken Sie hier um bei der Übersetzung von bitcoin.org in ihre Sprache zu helfen</a>."

--- a/_translations/el.yml
+++ b/_translations/el.yml
@@ -659,6 +659,7 @@ el:
     tax: "Κυβερνητικοί φόροι και κανονισμοί"
     taxtxt: "Το Bitcoin δεν συνιστά επίσημο νόμισμα. Ωστόσο, στα περισσότερα νομικά συστήματα απαιτείται ακόμα να πληρώνετε φόρους για εισοδήματα, πωλήσεις, μισθοδοσίες, υπεραξίες και γενικά για οτιδήποτε έχει αξία, συμπεριλαμβανομένων και των bitcoins. Είναι ευθύνη σας να επιβεβαιώσετε ότι τηρείτε <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">τις φορολογικές και λοιπές νομικές ή ρυθμιστικές εντολές</a> που εκδίδονται από την κυβέρνησή σας και/ή τους κατά τόπους δήμους."
   layout:
+    menu-support-bitcoin: "Υποστηρίξτε το Bitcoin"
     menu-about-us: "Σχετικά με το bitcoin.org"
     menu-bitcoin-for-businesses: Επιχειρήσεις
     menu-bitcoin-for-developers: Προγραμματιστές
@@ -676,7 +677,7 @@ el:
     menu-privacy: "Προστασία Προσωπικών Δεδομένων"
     menu-resources: Πόροι
     menu-stats: "Στατιστικά Στοιχεία"
-    menu-support-bitcoin: Συμμετοχή
+    menu-participate: Συμμετοχή
     menu-vocabulary: Λεξιλόγιο
     menu-you-need-to-know: "Πρέπει να γνωρίζετε"
     banner-translate: "Οι μεταφράσεις για αυτή την γλώσσα είναι ξεπερασμένες. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Κάντε κλικ εδώ για να βοηθήσετε στην μετάφραση του bitcoin.org στην γλώσσα σας.</a>."

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -678,11 +678,12 @@ en:
     menu-innovation: Innovation
     menu-intro: Introduction
     menu-legal: "Legal"
+    menu-participate: Participate
     menu-press: "Press"
     menu-privacy: "Privacy"
     menu-resources: Resources
     menu-stats: "Stats"
-    menu-support-bitcoin: Participate
+    menu-support-bitcoin: "Support Bitcoin"
     menu-vocabulary: Vocabulary
     menu-you-need-to-know: "You need to know"
     banner-translate: "Translations for this language are outdated. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Click here to help translate bitcoin.org in your language</a>."

--- a/_translations/es.yml
+++ b/_translations/es.yml
@@ -625,6 +625,7 @@ es:
     tax: "Impuestos y regulaciones"
     taxtxt: "El Bitcoin no es una moneda oficial. Dicho esto, en la mayoría de territorios usted tendrá que pagar renta, nóminas y los impuestos sobre ganancias en todo lo que tenga valor, incluyendo bitcoins. Es su responsabilidad asegurarse de aplicar los impuestos y otras regulaciones publicadas por su gobierno o municipio."
   layout:
+    menu-support-bitcoin: "Apoya Bitcoin"
     menu-about-us: "Acerca de bitcoin.org"
     menu-bitcoin-for-businesses: Empresas
     menu-bitcoin-for-developers: Desarrolladores
@@ -640,7 +641,7 @@ es:
     menu-legal: "Legal"
     menu-press: "Prensa"
     menu-resources: Recursos
-    menu-support-bitcoin: Participe
+    menu-participate: Participe
     menu-vocabulary: Vocabulario
     menu-you-need-to-know: "Cosas que necesita saber"
     banner-translate: "Las traducciones para este idioma están desactualizadas. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Haga clic aquí para ayudar a traducir bitcoin.org a su idioma</a>."

--- a/_translations/fa.yml
+++ b/_translations/fa.yml
@@ -628,6 +628,7 @@ fa:
     tax: "مالیات ها و مقررات دولتی"
     taxtxt: "بیت کوین ارزی رسمی نیست. یعنی بیشتر مراجع قضایی از شما خواهند خواست که مالیات های مربوط به درآمد، فروش، حقوق و بهره سرمایه ای را روی آنچه که ارزش دارد، از جمله بیت کوین، بپردازید. مسئولیت حصول اطمینان از  \n<a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\"> موارد مالیاتی و دیگر احکام قانونی یا مقرراتی </a> که توسط دولت  و یا شهرداریهای محلی وضع شده، بر عهده خود شماست."
   layout:
+    menu-support-bitcoin: "حمایت از بیت کوین"
     menu-about-us: "درباره bitcoin.org"
     menu-bitcoin-for-businesses: کسب و کارها
     menu-bitcoin-for-developers: توسعه دهندگان
@@ -645,7 +646,7 @@ fa:
     menu-privacy: "حریم خصوصی"
     menu-resources: منابع
     menu-stats: "نظامنامه ها"
-    menu-support-bitcoin: مشارکت
+    menu-participate: مشارکت
     menu-vocabulary: دایره واژگان
     menu-you-need-to-know: "لازم است بدانید"
     banner-translate: "ترجمه ها به این زبان، منسوخ شده اند.  <a href=\"https://github.com/bitcoin/bitcoin.org#translation\"> اینجا را کلیک کنید و به ترجمه bitcoin.org  به زبان خود، کمک کنید</a>."

--- a/_translations/fr.yml
+++ b/_translations/fr.yml
@@ -659,6 +659,7 @@ fr:
     tax: "Impôts et réglementations gouvernementales"
     taxtxt: "Bitcoin n'est pas une devise officielle. Ceci étant dit, la plupart des juridictions exigent que vous payiez des impôts sur le revenu, les ventes, les salaires et les gains en capital sur tout ce qui a de la valeur, incluant les bitcoins. Il est de votre responsabilité de vous assurer de respecter <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">les impôts, les mandats légaux et les réglementations</a> émises par votre gouvernement et / ou vos municipalités locales."
   layout:
+    menu-support-bitcoin: "Soutenir Bitcoin"
     menu-about-us: "À propos de bitcoin.org"
     menu-bitcoin-for-businesses: Entreprises
     menu-bitcoin-for-developers: Développeurs
@@ -676,7 +677,7 @@ fr:
     menu-privacy: "Confidentialité"
     menu-resources: Ressources
     menu-stats: "Statistiques"
-    menu-support-bitcoin: Participer
+    menu-participate: Participer
     menu-vocabulary: Vocabulaire
     menu-you-need-to-know: "Vous devez savoir"
     banner-translate: "Les traductions pour cette langue ne sont plus à jour.  <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Cliquez ici pour aider à traduire bitcoin.org dans votre langue</a>."

--- a/_translations/hi.yml
+++ b/_translations/hi.yml
@@ -659,6 +659,7 @@ hi:
     tax: "सरकार कर और नियम"
     taxtxt: "Bitcoin एक आधिकारिक मुद्रा नहीं है। हाँ लेकिन, अधिकांश क्षेत्राधिकार के अनुसार ये जरुरी होता है कि किसी भी मूल्य की चीज़ पर  जिसमें bitcoins शामिल हैं, बिक्री, पेरोल, और पूंजीगत लाभ पर कर आय का भुगतान किया जाए। यह आपकी जिम्मेदारी है कि आप  <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">टैक्स और अन्य कानूनी या  विनियामक जनादेश</a> का पालन करे जो सरकार  या/और स्थानीय नगर पालिकाओं द्वारा जारी किए गए हो। "
   layout:
+    menu-support-bitcoin: "Bitcoin समर्थन करें"
     menu-about-us: "bitcoin.org के बारे में"
     menu-bitcoin-for-businesses: व्यवसाय
     menu-bitcoin-for-developers: डेवलपर्स
@@ -676,7 +677,7 @@ hi:
     menu-privacy: "गोपनियता"
     menu-resources: संसाधन
     menu-stats: "आँकड़े"
-    menu-support-bitcoin: भाग लें
+    menu-participate: भाग लें
     menu-vocabulary: शब्दावली
     menu-you-need-to-know: "आपको पता होना चाहिए "
     banner-translate: "इन भाषाओं के लिए अनुवाद पुरानी हो चुकी है <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">अपनी भाषा में bitcoin.org के अनुवाद में मदद करने के लिए यहां क्लिक करें </a>."

--- a/_translations/hu.yml
+++ b/_translations/hu.yml
@@ -660,6 +660,7 @@ hu:
     tax: "Kormányzati adók és szabályozások"
     taxtxt: "A bitcoin nem hivatalos pénznem. Mindemellett a legtöbb törvényalkotó elvárja, hogy minden után, aminek értéke van - beleértve a bitcoinokat is - vállalkozói, forgalmi, jövedelem- és kamatadót fizessen. Az Ön felelőssége, hogy pontosan betartsa a kormánya és/vagy helyi önkormányzata által kibocsátott <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">adó- és egyéb jogi vagy szabályozói rendelkezéseket</a>."
   layout:
+    menu-support-bitcoin: "Támogassa a Bitcoint"
     menu-about-us: "A bitcoin.org-ról"
     menu-bitcoin-for-businesses: Vállalkozások
     menu-bitcoin-for-developers: Fejlesztők
@@ -677,7 +678,7 @@ hu:
     menu-privacy: "Adatvédelem"
     menu-resources: Információs anyagok
     menu-stats: "Statisztikák"
-    menu-support-bitcoin: Részvétel
+    menu-participate: Részvétel
     menu-vocabulary: Szótár
     menu-you-need-to-know: "Érdemes tudnia"
     banner-translate: "Az ehhez a nyelvhez tartozó fordítások elavultak. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">A bitcoin.org saját nyelvére történő fordításában való segítséghez kattintson ide </a>."

--- a/_translations/id.yml
+++ b/_translations/id.yml
@@ -659,6 +659,7 @@ id:
     tax: "Pajak pemerintah dan peraturan-peraturan."
     taxtxt: "Bitcoin bukanlah mata uang resmi. Artinya, sebagian besar negara masih meminta Anda untuk membayar pajak pendapatan, penjualan, penggajian, dan pajak keuntungan modal atas apapun yang memiliki nilai termasuk bitcoin. Merupakan tanggung jawab Anda untuk memastikan bahwa Anda mematuhi <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">pajak dan aturan hukum lainnya ataupun kebijakan</a> yang dikeluarkan oleh pemerintah Anda dan/atau pengambil kebijakan di daerah Anda.  "
   layout:
+    menu-support-bitcoin: "Dukung Bitcoin"
     menu-about-us: "Mengenai bitcoin.org"
     menu-bitcoin-for-businesses: Bisnis
     menu-bitcoin-for-developers: Para Pengembang
@@ -676,7 +677,7 @@ id:
     menu-privacy: "Privasi"
     menu-resources: Sumber daya
     menu-stats: "Statistik"
-    menu-support-bitcoin: Partisipasi
+    menu-participate: Partisipasi
     menu-vocabulary: Kosa kata
     menu-you-need-to-know: "Yang perlu Anda ketahui"
     banner-translate: "Terjemahan bahasa ini sudah ketinggalan jaman. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Klik di sini untuk membantu menerjemahkan bitcoin.org dalam</a> bahasa Anda."

--- a/_translations/it.yml
+++ b/_translations/it.yml
@@ -659,6 +659,7 @@ it:
     tax: "Costi fiscali e normativa"
     taxtxt: "Bitcoin non è una valuta ufficiale. Detto questo, la maggior parte degli ordinamenti giuridici richiede il pagamento di imposte sul reddito, sulle vendite, sui salari e sulle plusvalenze per qualunque cosa abbia valore, incluso Bitcoin. E' tua esclusiva responsabilità assicurarti di pagare le <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">imposte e rispettare tutte le norme</a> imposte dal tuo governo e/o dal tuo comune."
   layout:
+    menu-support-bitcoin: "Sostieni Bitcoin"
     menu-about-us: "A proposito di bitcoin.org"
     menu-bitcoin-for-businesses: Imprese
     menu-bitcoin-for-developers: Sviluppatori
@@ -676,7 +677,7 @@ it:
     menu-privacy: "Privacy"
     menu-resources: Risorse
     menu-stats: "Statistiche"
-    menu-support-bitcoin: Partecipa
+    menu-participate: Partecipa
     menu-vocabulary: Glossario
     menu-you-need-to-know: "Da sapere"
     banner-translate: "La traduzione per questa lingua è ormai datata.  <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Clicca qui per aiutarci a tradurre il sito bitcoin.org nella tua lingua</a>."

--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -659,6 +659,7 @@ ja:
     tax: "税金と規則"
     taxtxt: "ビットコインは公式通貨ではありません。ですが、ほとんどの管轄では、ビットコインを含め、価値あるものに対する所得、売り上げ、給与、キャピタルゲインに対し税金を課します。あなたの政府と/や自治体が定める<a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">税金やその他の法的あるいは規制義務</a>に従うことは、あなたの責任です。"
   layout:
+    menu-support-bitcoin: "ビットコインを支援する"
     menu-about-us: "bitcoin.org について"
     menu-bitcoin-for-businesses: ビジネス
     menu-bitcoin-for-developers: 開発者
@@ -676,7 +677,7 @@ ja:
     menu-privacy: "プライバシー"
     menu-resources: リソース
     menu-stats: "統計"
-    menu-support-bitcoin: 参加する
+    menu-participate: 参加する
     menu-vocabulary: 用語
     menu-you-need-to-know: "知っておくべきこと"
     banner-translate: "この言語の翻訳は古くなっています。<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">ここをクリックして、あなたの言語で bitcoin.org を翻訳する援助をしましょう</a>。"

--- a/_translations/ko.yml
+++ b/_translations/ko.yml
@@ -659,6 +659,7 @@ ko:
     tax: "정부규제와 세금"
     taxtxt: "비트코인은 공식적인 화폐가 아닙니다. 그런데다 대부분의 국가 및 지역에서는 소득, 판매, 급여, 자본 이득 등 가치를 가지고 있는 모든 것에 대해 세금을 납부하도록 요구하고 있습니다. 비트코인도 예외는 아닙니다. 당사자의 정부나 자치 당국에서 규정한 <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">납세 및 기타 법률과 규제 사항</a>을 준수하는 것은 이 글을 읽는 당사자의 책임임을 명확히 합니다."
   layout:
+    menu-support-bitcoin: "비트코인을 지지해주세요"
     menu-about-us: "bitcoin.org 소개"
     menu-bitcoin-for-businesses: 사업자
     menu-bitcoin-for-developers: '개발자 '
@@ -676,7 +677,7 @@ ko:
     menu-privacy: "개인 정보 보호"
     menu-resources: 자료
     menu-stats: "통계"
-    menu-support-bitcoin: 참여
+    menu-participate: 참여
     menu-vocabulary: 용어
     menu-you-need-to-know: "여러분이 알아두어야 할 것"
     banner-translate: "이 언어에 해당하는 번역이 오래되었습니다.<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">당신의 언어에 해당하는 bitcoin.org를 번역하시려면 이곳을 눌러주세요."

--- a/_translations/nl.yml
+++ b/_translations/nl.yml
@@ -659,6 +659,7 @@ nl:
     tax: "Overheidsbelastingen en regelgeving"
     taxtxt: "Bitcoin is geen officiële munteenheid. Dat gezegd hebbende, in de meeste landen moeten toch inkomsten-, vennootschaps-, vermogens- en omzetbelastingen worden betaald over alles wat waarde vertegenwoordigt, inclusief bitcoins. Het is uw verantwoordelijkheid om ervoor te zorgen dat u zich houdt aan de <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">belastingwetgeving en enige andere wettelijke of reglementaire mandaten</a> afgegeven door uw overheid en/of plaatselijke gemeenten."
   layout:
+    menu-support-bitcoin: "Help Bitcoin"
     menu-about-us: "Over bitcoin.org"
     menu-bitcoin-for-businesses: Bedrijven
     menu-bitcoin-for-developers: Ontwikkelaars
@@ -676,7 +677,7 @@ nl:
     menu-privacy: "Privacy"
     menu-resources: Hulpmiddelen
     menu-stats: "Statistieken"
-    menu-support-bitcoin: Meedoen
+    menu-participate: Meedoen
     menu-vocabulary: Woordenlijst
     menu-you-need-to-know: "Wat u moet weten"
     banner-translate: "Vertalingen voor deze taal zijn verouderd. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Klik hier om bitcoin.org naar uw taal te vertalen</a>."

--- a/_translations/pl.yml
+++ b/_translations/pl.yml
@@ -659,6 +659,7 @@ pl:
     tax: "Rządowe podatki i regulacje"
     taxtxt: "Bitcoin nie jest oficjalną walutą. Wiedząc to, pamiętaj, że większość jurysdykcji niezmiennie wymaga płacenia podatku dochodowego, od sprzedaży, kosztów uzyskania przychodu czy podatku od zysków ze sprzedaży towarów zawierających wartość, włączając w to bitcoiny. Twoim obowiązkiem jest upewnić się, że stosujesz się do <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">podatków i innych obowiązków ustawowych lub wykonawczych</a> wydanych przez organy państwowe lub samorządowe."
   layout:
+    menu-support-bitcoin: "Wesprzyj Bitcoin"
     menu-about-us: "O bitcoin.org"
     menu-bitcoin-for-businesses: Firm
     menu-bitcoin-for-developers: Deweloperów
@@ -676,7 +677,7 @@ pl:
     menu-privacy: "Prywatność"
     menu-resources: Zasoby
     menu-stats: "Statystyki"
-    menu-support-bitcoin: Weź udział
+    menu-participate: Weź udział
     menu-vocabulary: Słownik
     menu-you-need-to-know: "Musisz to wiedzieć"
     banner-translate: "Tłumaczenia dla tego języka są przestarzałe. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Kliknij tutaj, aby pomóc w tłumaczeniu bitcoin.org na Twój język</a>."

--- a/_translations/pt_BR.yml
+++ b/_translations/pt_BR.yml
@@ -660,6 +660,7 @@ pt_BR:
     tax: "Taxas e regulamentos dos governos."
     taxtxt: "Bitcoin não é uma moeda reconhecida oficialmente. Dito isto, a maioria dos governos exige que você pague impostos sobre quaisquer ganhos de capital, incluindo os relacionados a Bitcoin. É de sua responsabilidade aceitar os termos referentes a <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">a legislação tributária e fiscal</a>emitidos pelo seu governo e/ou municípios locais."
   layout:
+    menu-support-bitcoin: "Suporte Bitcoin"
     menu-about-us: "Sobre bitcoin.org"
     menu-bitcoin-for-businesses: Empresas
     menu-bitcoin-for-developers: Desenvolvedores
@@ -677,7 +678,7 @@ pt_BR:
     menu-privacy: "Privacidade"
     menu-resources: Recursos
     menu-stats: "Status"
-    menu-support-bitcoin: Participe
+    menu-participate: Participe
     menu-vocabulary: Vocabulário
     menu-you-need-to-know: "Você precisa saber"
     banner-translate: "Traduções para esse idioma não estão atualizadas. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Clique aqui para ajudar a traduzir bitcoin.org para o seu idioma</a>."

--- a/_translations/ro.yml
+++ b/_translations/ro.yml
@@ -659,6 +659,7 @@ ro:
     tax: "Taxe și reglementări guvernamentale"
     taxtxt: "Bitcoin nu este o valută oficială. Acestea fiind spuse, majoritatea jurisdictiilor încă necesită plata unor taxe pe profit sau vânzare asupra orice are valoare, inclusiv bitcoini. Este responsabilitatea ta să te asiguri că respecţi <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">taxele, impozitele şi oricare alte mandate legale sau regulatorii</a> impuse de guvern sau municipalităţile locale."
   layout:
+    menu-support-bitcoin: "Susţine Bitcoin"
     menu-about-us: "Despre bitcoin.org"
     menu-bitcoin-for-businesses: Companii
     menu-bitcoin-for-developers: Dezvoltatori
@@ -676,7 +677,7 @@ ro:
     menu-privacy: "Confidenţialitate"
     menu-resources: Resurse
     menu-stats: "Statistici"
-    menu-support-bitcoin: Participă
+    menu-participate: Participă
     menu-vocabulary: Vocabular
     menu-you-need-to-know: "Trebuie să știi"
     banner-translate: "Traducerile in aceasta limba sunt vechi.<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Click aici pentru a ajuta traducerea bitcoin.org in limba ta</a>."

--- a/_translations/ru.yml
+++ b/_translations/ru.yml
@@ -665,6 +665,7 @@ ru:
     tax: "Налоги и госрегулирование"
     taxtxt: "Биткойн не является официальной валютой. Тем не менее, большинство юрисдикций требуют, чтобы вы платили подоходный налог, что может относиться и к Биткойну. Это ваша ответственность, убедитесь, что вы будете придерживаться <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\"> налоговых и других юридических или нормативных требований</a>  вашего правительства и/или местных властей."
   layout:
+    menu-support-bitcoin: "Поддержать Биткойн"
     menu-about-us: "О bitcoin.org"
     menu-bitcoin-for-businesses: Бизнесу
     menu-bitcoin-for-developers: Разработчикам
@@ -682,7 +683,7 @@ ru:
     menu-privacy: "Конфиденциальность"
     menu-resources: Ресурсы
     menu-stats: "Статистика"
-    menu-support-bitcoin: Участвовать
+    menu-participate: Участвовать
     menu-vocabulary: Термины
     menu-you-need-to-know: "Вам нужно знать"
     banner-translate: "Переводы на этот язык устарели.  <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Кликните здесь чтобы помочь перевести bitcoin.org на ваш язык</a>."

--- a/_translations/sl.yml
+++ b/_translations/sl.yml
@@ -624,6 +624,7 @@ sl:
     tax: "Davki in zakonodaja"
     taxtxt: "Bitcoin ni uradna valuta. Še vedno pa večina zakonodaj zahteva, da plačate davke na dohodek, dobiček, plače itd. za vse stvari, ki imajo kako vrednost, vključno z bitcoini. Vaša odgovornost je, da se pozanimate in sledite davčnim in drugim zakonom države in kraja, kjer živite. Nekaj informacij, tudi o Sloveniji, lahko najdete na <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country#Slovenia\">Wikipedia</a>."
   layout:
+    menu-support-bitcoin: "Podprite bitcoin"
     menu-about-us: "O bitcoin.org"
     menu-bitcoin-for-businesses: Podjetja
     menu-bitcoin-for-developers: Razvijalci
@@ -639,7 +640,7 @@ sl:
     menu-legal: "Pravno"
     menu-press: "Mediji"
     menu-resources: Viri
-    menu-support-bitcoin: Sodelujte
+    menu-participate: Sodelujte
     menu-vocabulary: Slovar
     menu-you-need-to-know: "Obvezno branje"
     banner-translate: "Prevodi v tem jeziku so zastareli. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Kliknite tu, če želite pomagati prevajati bitcoin.org v svoj jezik</a>."

--- a/_translations/sv.yml
+++ b/_translations/sv.yml
@@ -572,6 +572,7 @@ sv:
     experimentaltxt: "Bitcoin är en experimentell och ny valuta som är under aktiv utveckling. Medan det blir stabilare allt eftersom användningen ökar så bör du komma ihåg att Bitcoin är en ny uppfinning som utforskar idéer som aldrig har prövats förut. Därför kan ingen förutse dess framtid."
     tax: "Statliga skatter och förordningar"
   layout:
+    menu-support-bitcoin: "Stöd Bitcoin"
     menu-about-us: "Om bitcoin.org"
     menu-bitcoin-for-businesses: Företag
     menu-bitcoin-for-developers: Utvecklare
@@ -588,7 +589,7 @@ sv:
     menu-privacy: "Integritet"
     menu-resources: Resurser
     menu-stats: "Statistik"
-    menu-support-bitcoin: Delta
+    menu-participate: Delta
     menu-vocabulary: Ordlista
     menu-you-need-to-know: "Du måste veta"
     footer: "Publicerad under  <a href=\"http://opensource.org/licenses/mit-license.php\" target=\"_blank\">MIT licensen</a>"

--- a/_translations/tr.yml
+++ b/_translations/tr.yml
@@ -660,6 +660,7 @@ tr:
     tax: "Hükümet vergileri ve denetimler"
     taxtxt: "Bitcoin resmi bir para birimi değildir. Bununla birlikte çoğu hükümet yinede sizden gelir ödeme, satış, ücret bordrosu ve bitcoin dahil değeri olan herşey için vergi ödemenizi ister. Hükümetiniz veya/yada yerel belediyeleriniz tarafından yayınlanan <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">vergi ve diğer mevzuat mandalarını</a> anladığınıza emin olmak sizin sorumluluğunuzdur."
   layout:
+    menu-support-bitcoin: "Bitcoin'i Destekleyin"
     menu-about-us: "Bitcoin.org hakkında"
     menu-bitcoin-for-businesses: İşletmeler
     menu-bitcoin-for-developers: Geliştiriciler
@@ -677,7 +678,7 @@ tr:
     menu-privacy: "Gizlilik"
     menu-resources: Kaynaklar
     menu-stats: "İstatislikler"
-    menu-support-bitcoin: Katılın
+    menu-participate: Katılın
     menu-vocabulary: Sözlük
     menu-you-need-to-know: "Bilmeniz gerekenler"
     banner-translate: "Bu dil için çeviriler güncel değildir.  <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">bitcoin.org'un dilinize çevrilmesine yardım etmek için buraya tıklayın</a>."

--- a/_translations/uk.yml
+++ b/_translations/uk.yml
@@ -659,6 +659,7 @@ uk:
     tax: "Податки та державне регулювання"
     taxtxt: "Біткойн не є офіційною валютою. Тим не менше, більшість юрисдикцій вимагають, щоб ви сплачували податки на прибуток, з продажу, на заробітну плату та податок на приріст вартості капіталу з будь-чого, що має цінність, включаючи біткоїни. Ви несете відповідальність за дотримання <a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">податкових та інших юридичних або нормативних вимог</a> вашого уряду та/або місцевої влади.   "
   layout:
+    menu-support-bitcoin: "Підтримка Біткойн"
     menu-about-us: "Про bitcoin.org"
     menu-bitcoin-for-businesses: Бізнесу
     menu-bitcoin-for-developers: Розробникам
@@ -676,7 +677,7 @@ uk:
     menu-privacy: "Конфіденційність"
     menu-resources: Ресурси
     menu-stats: "Статистика"
-    menu-support-bitcoin: Взяти участь
+    menu-participate: Взяти участь
     menu-vocabulary: Словник
     menu-you-need-to-know: "Ви повинні це знати"
     banner-translate: "Переклад цією мовою застарілий. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Клікніть сюди, щоб допомогти перекласти bitcoin.org вашою мовою</a>. "

--- a/_translations/zh_CN.yml
+++ b/_translations/zh_CN.yml
@@ -659,6 +659,7 @@ zh_CN:
     tax: "政府税收和法规"
     taxtxt: "比特币不是一种官方货币。也就是说，大多数的行政区域还是会要求你缴纳收入、销售、工资和投资收益等有价值的东西的税款，这其中也包括比特币。确保你遵守了政府和/或者当地市政机关制定的<a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">税收和其他法律法规</a>是你自己的责任。"
   layout:
+    menu-support-bitcoin: "支持比特币"
     menu-about-us: "关于bitcoin.org"
     menu-bitcoin-for-businesses: 商家
     menu-bitcoin-for-developers: 开发者
@@ -676,7 +677,7 @@ zh_CN:
     menu-privacy: "隐私"
     menu-resources: 资源
     menu-stats: "统计数据"
-    menu-support-bitcoin: 参与
+    menu-participate: 参与
     menu-vocabulary: 词汇表
     menu-you-need-to-know: "注意事项"
     banner-translate: "这种语言的翻译已经过期了。<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">点击这里来帮助把 bitcoin.org 翻译成你的语言</a>。"

--- a/_translations/zh_TW.yml
+++ b/_translations/zh_TW.yml
@@ -659,6 +659,7 @@ zh_TW:
     tax: "政府稅收和規定"
     taxtxt: "Bitcoin 並非官方貨幣。也即是說，大部分的稽稅機關仍會要求您針對任何有價值的收入、營業所得、薪水、資產利得來納稅，包括 Bitcoin。確保遵守您的政府和/或當地市政當局頒發的<a href=\"https://en.wikipedia.org/wiki/Legality_of_bitcoin_by_country\">納稅和其他強制法律法規</a>是您的責任。"
   layout:
+    menu-support-bitcoin: "支持 Bitcoin"
     menu-about-us: "關於 bitcoin.org"
     menu-bitcoin-for-businesses: 商務
     menu-bitcoin-for-developers: 開發人員
@@ -676,7 +677,7 @@ zh_TW:
     menu-privacy: "隱私性"
     menu-resources: 資源
     menu-stats: "統計數據"
-    menu-support-bitcoin: 參與
+    menu-participate: 參與
     menu-vocabulary: 詞彙
     menu-you-need-to-know: "使用須知"
     banner-translate: "這種語言的翻譯已經過時。<a href=\"https://github.com/bitcoin/bitcoin.org#translation\">點擊這裡來幫助把bitcoin.org 翻譯成您的語言</a>。"


### PR DESCRIPTION
Live preview: http://bitcointest1.us.to/

I remember reading comments saying the "Development" page was buried and hard to find, and the current guide to run a full node isn't visible in the menus either. I feel like these two would find their right audience and get more visibility by becoming a submenu of the "Participate" menu entry.

![capture du 2015-04-09 17 38 46](https://cloud.githubusercontent.com/assets/3578089/7077515/5972f18e-dedf-11e4-88f6-06b6587673be.png)
