### PR TITLE
Skip htmlproofer when partially building the website

### DIFF
--- a/_contrib/bco-htmlproof
+++ b/_contrib/bco-htmlproof
@@ -2,6 +2,12 @@
 
 require 'html/proofer'
 
+## Don't check links when partially building the website.
+if !ENV['ENABLED_PLUGINS'].nil? or !ENV['ENABLED_LANGS'].nil?
+  print 'HTMLProofer skipped (partial build)' + "\n"
+  exit
+end
+
 ## Will throw an exception (exiting false) if any internal links don't
 ## work. The Makefile will terminate on the failure
 HTML::Proofer.new(


### PR DESCRIPTION
This little change allows me to benefit from other Makefile tests by getting meaningful build failures when doing partial builds. I guess HTMLProofer cannot do much in this specific case, as having missing pages and broken links is an expected outcome of doing a partial build.

(Note: If we later choose to go as far as to validate HTML, we could easily tell HTMLProofer to only do HTML validation and skip link checks)