### PR TITLE
Fix endless loop bug in build scripts

### DIFF
--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -49,13 +49,18 @@ lasttime=`stat -c %Y "$SITEDIR/_buildlock" | cut -d ' ' -f1`
 # Build website in a child process
 (
 cd $WORKDIR
-JEKYLL_COMMAND='jekyll' make build
-touch "$WORKDIR/_builddone"
+make valid && touch "$WORKDIR/_builddone" || touch "$WORKDIR/_buildfail"
 )&
 
 # Loop every 1 second to check status
 while true
 do
+
+	# Exit if site has been failed to build
+	if [ -e "$WORKDIR/_buildfail" ]; then
+		echo "Build failed"
+		exit
+	fi
 
 	# Update site and exit if site has been successfully built
 	if [ -e "$WORKDIR/_builddone" ]; then
@@ -69,6 +74,7 @@ do
 		time=`stat -c %Y "$SITEDIR/_buildlock" | cut -d ' ' -f1`
 	fi
 	if [ $time != $lasttime ]; then
+		echo "Build cancelled"
 		exit
 	fi
 	sleep 1

--- a/_build/update_txpreview.sh
+++ b/_build/update_txpreview.sh
@@ -91,13 +91,18 @@ done
 # Build website in a child process
 (
 cd $WORKDIR
-ENABLED_PLUGINS='alerts redirects releases' JEKYLL_COMMAND='jekyll' make
-touch "$WORKDIR/_builddone"
+ENABLED_PLUGINS='alerts redirects releases' make build && touch "$WORKDIR/_builddone" || touch "$WORKDIR/_buildfail"
 )&
 
 # Loop every 1 second to check status
 while true
 do
+
+	# Exit if site has been failed to build
+	if [ -e "$WORKDIR/_buildfail" ]; then
+		echo "Build failed"
+		exit
+	fi
 
 	# Update site and exit if site has been successfully built
 	if [ -e "$WORKDIR/_builddone" ]; then
@@ -112,6 +117,7 @@ do
 		time=`stat -c %Y "$SITEDIR/site/_buildlock" | cut -d ' ' -f1`
 	fi
 	if [ $time != $lasttime ]; then
+		echo "Build cancelled"
 		exit
 	fi
 	sleep 1


### PR DESCRIPTION
The subshell used in the script to prevent it from building if another concurrent build starts had the unintended consequence of creating an endless loop when the build script fails.

This pull request allows the script to terminate correctly.

Additionally this pull request enables the quick Makefile tests to catch issues in order to prevent the server to push any broken update (as we've already planned to do, it currently works fine on the build machine according to my testing).