### PR TITLE
Dev Docs: Update For New 'generate' RPC

### DIFF
--- a/_autocrossref.yaml
+++ b/_autocrossref.yaml
@@ -399,6 +399,8 @@ CVE-2012-2459:
 '`estimatefee` RPC': rpc estimatefee
 '`estimatepriority`': rpc estimatepriority
 '`estimatepriority` RPC': rpc estimatepriority
+'`generate`': rpc generate
+'`generate` RPC': rpc generate
 '`getaccount`': rpc getaccount
 '`getaccount` RPC': rpc getaccount
 '`getaccountaddress`': rpc getaccountaddress

--- a/_includes/example_testing.md
+++ b/_includes/example_testing.md
@@ -64,12 +64,16 @@ Start `bitcoind` in regtest mode to create a private block chain.
 {% endautocrossref %}
 
 ~~~
+## Bitcoin Core 0.10.1 and earlier
 bitcoin-cli -regtest setgenerate true 101
+
+## Bitcoin Core master (as of commit 48265f3)
+bitcoin-cli -regtest generate 101
 ~~~
 
 {% autocrossref %}
 
-Generate 101 blocks using a special version of the `setgenerate` RPC
+Generate 101 blocks using a special RPC
 which is only available in regtest mode. This takes about 30 seconds on
 a generic PC. Because this is a new block chain using Bitcoin's default
 rules, the first blocks pay a block reward of 50 bitcoins.  Unlike

--- a/_includes/example_transactions.md
+++ b/_includes/example_transactions.md
@@ -115,7 +115,11 @@ someone else, that second transaction would not be displayed in our
 list of UTXOs.
 
 {% highlight bash %}
+## Bitcoin Core 0.10.1 and earlier
 > bitcoin-cli -regtest setgenerate true 1
+
+## Later versions of Bitcoin Core
+> bitcoin-cli -regtest generate 1
 
 > unset NEW_ADDRESS
 {% endhighlight %}
@@ -332,7 +336,11 @@ would usually then broadcast it to other peers, but we're not currently
 connected to other peers because we started in regtest mode.
 
 {% highlight bash %}
+## Bitcoin Core 0.10.1 and earlier
 > bitcoin-cli -regtest setgenerate true 1
+
+## Later versions of Bitcoin Core
+> bitcoin-cli -regtest generate 1
 
 > unset UTXO_TXID UTXO_VOUT NEW_ADDRESS RAW_TX SIGNED_RAW_TX
 {% endhighlight %}

--- a/_includes/helpers/summaries.md
+++ b/_includes/helpers/summaries.md
@@ -12,6 +12,7 @@ This file is licensed under the terms of its source texts{%endcomment%}
 {% assign summary_encryptWallet="encrypts the wallet with a passphrase.  This is only to enable encryption for the first time. After encryption is enabled, you will need to enter the passphrase to use private keys." %}
 {% assign summary_estimateFee="estimates the transaction fee per kilobyte that needs to be paid for a transaction to be included within a certain number of blocks." %}
 {% assign summary_estimatePriority="estimates the priority that a transaction needs in order to be included within a certain number of blocks as a free high-priority transaction." %}
+{% assign summary_generate="nearly instantly generates blocks (in regtest mode only)" %}
 {% assign summary_getAccountAddress="returns the current Bitcoin address for receiving payments to this account. If the account doesn't exist, it creates both the account and a new address for receiving payment.  Once a payment has been received to an address, future calls to this RPC for the same account will return a different address." %}
 {% assign summary_getAccount="returns the name of the account associated with the given address." %}
 {% assign summary_getAddedNodeInfo="returns information about the given added node, or all added nodes (except onetry nodes). Only nodes which have been manually added using the `addnode` RPC will have their information displayed." %}

--- a/_includes/ref/bitcoin-core/rpcs/quick-ref.md
+++ b/_includes/ref/bitcoin-core/rpcs/quick-ref.md
@@ -17,6 +17,7 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% endcomment %}
 
 <!-- master -->
+{% assign NEW_MASTER='**<abbr title="New in Bitcoin Core’s master branch (unreleased)">New in master</abbr>**' %}
 {% assign UPDATED_MASTER='**<abbr title="Updated in Bitcoin Core’s master branch (unreleased)">Updated in master</abbr>**' %}
 
 <!-- Bitcoin Core 0.10.0 expected January 2015 -->
@@ -76,8 +77,9 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 
 {% autocrossref %}
 
+* [Generate][rpc generate]: {{summary_generate}} {{NEW_MASTER}}
 * [GetGenerate][rpc getgenerate]: {{summary_getGenerate}}
-* [SetGenerate][rpc setgenerate]: {{summary_setGenerate}}
+* [SetGenerate][rpc setgenerate]: {{summary_setGenerate}} {{UPDATED_MASTER}}
 
 {% endautocrossref %}
 

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/generate.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/generate.md
@@ -1,0 +1,64 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+{% assign filename="_includes/ref/bitcoin-core/rpcs/rpcs/generate.md" %}
+
+##### Generate
+{% include helpers/subhead-links.md %}
+
+{% assign summary_generate="nearly instantly generates blocks (in regtest mode only)" %}
+
+{% autocrossref %}
+
+*Requires wallet support.*
+
+The `generate` RPC {{summary_generate}}
+
+*Parameter #1---the number of blocks to generate*
+
+{% itemplate ntpd1 %}
+- n: "Blocks"
+  t: "number (int)"
+  p: "Required<br>(exactly 1)"
+  d: "The number of blocks to generate.  The RPC call will not return until all blocks have been generated"
+{% enditemplate %}
+
+*Result---the generated block header hashes*
+
+{% itemplate ntpd1 %}
+- n: "`result`"
+  t: "array"
+  p: "Required<br>(exactly 1)"
+  d: "An array containing the block header hashes of the generated blocks (may be empty if used with `generate 0`)"
+
+- n: "→<br>Header Hashes"
+  t: "string (hex)"
+  p: "Required<br>(1 or more)"
+  d: "The hashes of the headers of the blocks generated in regtest mode, as hex in RPC byte order"
+{% enditemplate %}
+
+*Examples from Bitcoin Core master (commit c2fa0846)*
+
+Using regtest mode, generate 2 blocks:
+
+{% highlight bash %}
+bitcoin-cli -regtest generate 2
+{% endhighlight %}
+
+Result:
+
+{% highlight json %}
+[
+    "36252b5852a5921bdfca8701f936b39edeb1f8c39fffe73b0d8437921401f9af",
+    "5f2956817db1e386759aa5794285977c70596b39ea093b9eab0aa4ba8cd50c06"
+]
+{% endhighlight %}
+
+*See also*
+
+* [SetGenerate][rpc getgenerate]: {{summary_getGenerate}}
+* [GetMiningInfo][rpc getmininginfo]: {{summary_getMiningInfo}}
+* [GetBlockTemplate][rpc getblocktemplate]: {{summary_getBlockTemplate}}
+
+{% endautocrossref %}

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/setgenerate.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/setgenerate.md
@@ -37,6 +37,9 @@ The `setgenerate` RPC {{summary_setGenerate}}
 
 *Parameter #2 (regtest)---the number of blocks to generate*
 
+Note: setgenerate in regtest mode has been removed in Bitcoin Core
+master. See the `generate` RPC for the replacement.
+
 {% itemplate ntpd1 %}
 - n: "Blocks"
   t: "number (int)"

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -230,6 +230,7 @@ http://opensource.org/licenses/MIT.
 [rpc encryptwallet]: /en/developer-reference#encryptwallet
 [rpc estimatefee]: /en/developer-reference#estimatefee
 [rpc estimatepriority]: /en/developer-reference#estimatepriority
+[rpc generate]: /en/developer-reference#generate
 [rpc getaccount]: /en/developer-reference#getaccount
 [rpc getaccountaddress]: /en/developer-reference#getaccountaddress
 [rpc getaddednodeinfo]: /en/developer-reference#getaddednodeinfo

--- a/en/developer-reference.md
+++ b/en/developer-reference.md
@@ -80,6 +80,8 @@ untrusted source.
 
 {% include ref/bitcoin-core/rpcs/rpcs/estimatepriority.md %}
 
+{% include ref/bitcoin-core/rpcs/rpcs/generate.md %}
+
 {% include ref/bitcoin-core/rpcs/rpcs/getaccountaddress.md %}
 
 {% include ref/bitcoin-core/rpcs/rpcs/getaccount.md %}


### PR DESCRIPTION
Preview: http://dg2.dtrt.org/en/developer-reference#generate

* Add a new section to the RPC docs describing the new `generate` RPC

* Mention that the `setgenerate` special mode in regtest has been removed in master

* Update raw transaction tutorial on the Examples doc to describe `generate` in addition to `setgenerate`

The need to update the docs was [mentioned on bitcoin-development](http://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg07369.html) by @sipa (thanks!)