### PR TITLE
About Us: Minor Updates

### DIFF
--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -32,23 +32,15 @@ id: about-us
 <h3 id="maintenance">{% translate maintenance %}</h3>
 
 <div class="credit">
-  <p><a href="mailto:saivann@gmail.com">Saïvann Carignan</a><span>Website maintenance</span></p>
-  <p>Garland William Binns III<span>Translation maintenance</span></p>
-  <p><a href="http://dtrt.org/">David Harding</a><span>Documentation maintenance</span></p>
-</div>
-
-<h3 id="documentation">{% translate documentation %}</h3>
-
-<div class="credit">
-  <p><a href="http://dtrt.org/">David Harding</a><span>Coordination and writing</span></p>
-  <p>Greg Sanders<span>Writing</span></p>
+  <p><a href="https://github.com/saivann/">Saïvann Carignan</a><span>Website maintenance<br>Translation coordination</span></p>
+  <p><a href="https://github.com/harding">David A. Harding</a><span>Website maintenance<br>Volunteer coordination<br>Documentation writing</span></p>
+  <p><a href="https://github.com/crwatkins">Craig Watkins</a><span>Wallet reviews</span></p>
 </div>
 
 <h3 id="translation">{% translate translation %}</h3>
 
 <div class="credit">
-  <p>Garland William Binns III<span>Maintenance</span></p>
-  <p>@arvicco<span>Russian</span></p>
+  <p>Ar Vicco<span>Russian</span></p>
   <p>Simon Alexander Hinterreiter<span>German</span></p>
   <p>Jacob Burenstam<span>Swedish</span></p>
   <p>Péter Kemenczés<span>Hungarian</span></p>
@@ -57,6 +49,13 @@ id: about-us
   <p>Boštjan Pirnar<span>Slovenian</span></p>
   <p>Luigigiuseppe Prosperi<span>Italian</span></p>
   <p>Thomas Pryds<span>Danish</span></p>
+</div>
+
+<h3 id="inactive-contributors">{% translate inactive_contributors %}</h3>
+
+<div class="credit">
+  <p>Garland William Binns III<span>Translation maintenance</span></p>
+  <p>Greg Sanders<span>Documentation Writing</span></p>
 </div>
 
 <h3 id="github">{% translate github %}</h3>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -20,6 +20,7 @@ en:
     maintenance: "Maintenance"
     documentation: "Documentation"
     translation: "Translation"
+    inactive_contributors: "Inactive Contributors"
     github: "Contributors on GitHub"
   bitcoin-for-businesses:
     title: "Bitcoin for Businesses - Bitcoin"


### PR DESCRIPTION
* Add Craig Watkins (wallet reviews) @crwatkins

* Remove long-idle contributors

* Update all personal links to point to GitHub, which allows contributors to set email/web addresses

Looks like this:

![2015-04-29-061847_735x253_scrot](https://cloud.githubusercontent.com/assets/61096/7389699/6f9b6e64-ee3e-11e4-8415-a549164f6fba.png)
