### PR TITLE
Separate event script from event data

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1942,6 +1942,9 @@ h2 .rssicon{
 	background-image:none;
 	color:#fff;
 }
+.eventdata{
+	display:none;
+}
 
 .detectmobile{
 	width:0;

--- a/_plugins/events.rb
+++ b/_plugins/events.rb
@@ -79,7 +79,7 @@ module Jekyll
         time.utc
         date = time.year.to_s + '-' + time.month.to_s.rjust(2,'0') + '-' + time.day.to_s.rjust(2,'0')
         country = country.upcase
-        geoloc = lat + ', ' + lon
+        geoloc = {'lat' => lat, 'lon' => lon}
         # Use address_2 and state when available
         if m['venue'].has_key?('address_2') and ( m['venue']['address_2'].is_a?(String) or m['venue']['address_2'].is_a?(Integer) or m['venue']['address_2'].is_a?(Float) ) and /^.{1,150}$/.match(m['venue']['address_2'].to_s)
           address = address + ' ' + m['venue']['address_2'].to_s
@@ -105,7 +105,7 @@ module Jekyll
           begin
             geoloc = JSON.parse(open("https://maps.googleapis.com/maps/api/geocode/json?address=" + CGI::escape(data['address'] + ', ' + data['city'] + ', ' + data['country']) + "&sensor=false","User-Agent"=>"Ruby/#{RUBY_VERSION}").read)
             if geoloc['status'] == 'OK'
-              data['geoloc'] = geoloc['results'][0]['geometry']['location']['lat'].to_s + ", " + geoloc['results'][0]['geometry']['location']['lng'].to_s
+              data['geoloc'] = {'lat' => geoloc['results'][0]['geometry']['location']['lat'].to_s, 'lon' => geoloc['results'][0]['geometry']['location']['lng'].to_s}
             end
           rescue
             print 'Google Maps API Call Failed!'

--- a/_templates/events.html
+++ b/_templates/events.html
@@ -5,6 +5,7 @@
 layout: base
 id: events
 ---
+<!-- Note: this file is built non-deterministically -->
 <link rel="alternate" type="application/rss+xml" href="/en/rss/events.rss" title="Bitcoin conferences and events">
 <h1>{% translate pagetitle %}<a type="application/rss+xml" href="/en/rss/events.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h1>
 <p class="summary">{% translate pagedesc %}</p>
@@ -15,6 +16,17 @@ id: events
 <script src="/js/leaflet/leaflet.js"></script>
 <script src="/js/leaflet-markercluster/leaflet.markercluster.js"></script>
 <div id="eventmap" class="eventmap"></div>
+<div id="eventdata" class="eventdata">
+
+{% filter_for p in site.conferences sort_by:date %}{% if p.geoloc %}
+<div data-lat="{{ p.geoloc.lat }}" data-lon="{{ p.geoloc.lon }}"><b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}')</div>
+{% endif %}{% endfilter_for %}
+
+{% filter_for p in site.meetups sort_by:date %}{% if p.geoloc %}
+<div data-lat="{{ p.geoloc.lat }}" data-lon="{{ p.geoloc.lon }}"><b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}</div>
+{% endif %}{% endfilter_for %}
+
+</div>
 <script src="/js/events.js"></script>
 <h2 id="upcoming">{% translate upcoming %}</h2>
 <div class="listtable eventtable">

--- a/js/events.js
+++ b/js/events.js
@@ -3,7 +3,7 @@ layout: null
 ---
 var zoom=2;
 var minzoom=1;
-if(/Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent))var zoom=minzoom=0;
+if(isMobile())var zoom=minzoom=0;
 var map = L.map('eventmap',{ 'zoom': zoom, 'minZoom': minzoom, 'center': [20.00, 10.00]});
 L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	attribution: 'Data &copy; by <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>.',
@@ -11,12 +11,8 @@ L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 var markers = new L.MarkerClusterGroup({showCoverageOnHover: false, maxClusterRadius: 40});
-{% filter_for p in site.conferences sort_by:date %}{% if p.geoloc %}
-L.marker([{{ p.geoloc }}]).bindPopup('<b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}').addTo(markers);
-{% endif %}{% endfilter_for %}
-
-{% filter_for p in site.meetups sort_by:date %}{% if p.geoloc %}
-L.marker([{{ p.geoloc }}]).bindPopup('<b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}').addTo(markers);
-{% endif %}{% endfilter_for %}
+for (var i=0, nds=document.getElementById('eventdata').getElementsByTagName('DIV'), n=nds.length; i < n; i++) {
+	L.marker([parseFloat(nds[i].getAttribute('data-lat')), parseFloat(nds[i].getAttribute('data-lon'))]).bindPopup(nds[i].innerHTML).addTo(markers);
+}
 
 map.addLayer(markers);


### PR DESCRIPTION
When monitoring sensitive changes on the website, regular script changes on all event pages are generating unhelpful non-descriptive noise, which might grab my attention away from real suspicious script changes.

This change renders events links and data directly on the page (inside an hidden DIV) and lets the script grab required data from there instead.