### PR TITLE
Add alt convention october 2015

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -86,6 +86,14 @@
   country: "USA"
   link: "http://www.coincongressevents.org"
 
+- date: 2015-10-08
+  title: "Alt Convention"
+  venue: "Hilton Batumi, Radisson Blu Batumi, Sheraton Batumi, Divan Suites, Leogrand"
+  address:
+  city: "Batumi"
+  country: "Georgia"
+  link: "http://altconvention.com"
+
 - date: 2015-11-09
   title: "MTBIT - Bitcoin & Remittances Miami Beach"
   venue: "Eden Roc Hotel"

--- a/_events.yml
+++ b/_events.yml
@@ -73,7 +73,7 @@
 - date: 2015-07-10
   title: "Inside Bitcoins Chicago"
   venue: "Navy Pier"
-  address: "600 East Grand Ave, Chaicago, IL 60611"
+  address: "600 East Grand Ave, Chicago, IL 60611"
   city: "Chicago"
   country: "United States"
   link: "http://insidebitcoins.com/chicago/2015?utm_source=bitcoinorg&utm_medium=eventlisting&utm_campaign=bitcoinorgeventlistingibchicago"


### PR DESCRIPTION
Closes #857. Left address blank because there are multiple venues this convention is being hosted across in the area.

Location: Batumi, Georgia
Website: http://altconvention.com/