### PR TITLE
Add Ninki Wallet iOS and Android to choose your wallet

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -819,6 +819,42 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
           privacynetwork: "checkfailprivacynetworknosupporttor"
+    platform:
+      ios:
+        text: "walletninki"
+        link: "https://itunes.apple.com/us/app/ninki-wallet/id965528267?mt=8"
+        source: "https://github.com/Ninkip2p/NinkiCordova"
+        screenshot: "ninki.png"
+        os:
+        - ios
+        check:
+          control: "checkpasscontrolmulti"
+          validation: "checkfailvalidationcentralized"
+          transparency: "checkfailtransparencynew"
+          environment: "checkpassenvironmenttwofactor"
+          privacy: "checkpassprivacybasic"
+        privacycheck:
+          privacyaddressreuse: "checkpassprivacyaddressrotation"
+          privacydisclosure: "checkfailprivacydisclosureaccount"
+          privacynetwork: "checkfailprivacynetworknosupporttor"
+    platform:
+      android:
+        text: "walletninki"
+        link: "https://play.google.com/store/apps/details?id=com.ninki.wallet&hl=en"
+        source: "https://github.com/Ninkip2p/NinkiCordova"
+        screenshot: "ninki.png"
+        os:
+        - android
+        check:
+          control: "checkpasscontrolmulti"
+          validation: "checkfailvalidationcentralized"
+          transparency: "checkfailtransparencynew"
+          environment: "checkpassenvironmenttwofactor"
+          privacy: "checkpassprivacybasic"
+        privacycheck:
+          privacyaddressreuse: "checkpassprivacyaddressrotation"
+          privacydisclosure: "checkfailprivacydisclosureaccount"
+          privacynetwork: "checkfailprivacynetworknosupporttor"
 ---
 
 <!-- Note: this file exempt from check-for-subheading-anchors check -->

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -797,7 +797,7 @@ wallets:
 - ninki:
     title: "Ninki Wallet"
     titleshort: "Ninki"
-    compat: "desktop windows mac linux"
+    compat: "desktop windows mac linux android ios"
     level: 3
     platform:
       desktop:


### PR DESCRIPTION
This is a request to include Ninki Wallet in iOS and Android in the choose your wallet section. We have previously been through a full review by Craig for the mobile releases but wanted to hold back until these latest versions were ready.

There is one major change that you should be aware of:

Ninki is a 2 of 3 Multisig wallet where the user controls 2 keys and Ninki controls one. Normally the user will create an account on the Desktop Chrome App and then pair with the phone. The user's keys are generated locally on the Chrome App and written down by the user. One of the keys is used to recover the account in the event that our service is offline and so must be written down at the point of account creation.

This presents a problem if we wish to allow users to sign up using the mobile app. Often they are not in a situation that is appropriate to write down the key and so in our UAT testing we found they were likely to skip this step.

We needed a solution which allowed the user to write down the recovery key at a later time without revealing the key to us. We also need a solution that retains the current security level of the mobile app. That if the phone is compromised, there is not a single target to attack and control the wallet.

@dabura667 proposed a method of achieving this goal.

The Recovery key is derived from 3 sources:

Device key- 128 bits of entropy
Secret key- 128 bits of entropy
Online key- 128 bits of entropy

The Recovery key is the first 128 bits a SHA256 of the device key ECMULT by an EC public key derived from the secret key concatenated with the online key. The EC public key is stored on the Ninki server until the time the user confirms that they key has been written down. Once confirmed the Device key is deleted from the device and the ECPubKey is deleted from the server.

Create Key

Secret key->ECPubKey (Pub key stored on server)
Device key
Online key

SHA256(Device key * ECPubKey || Online key)

Take first 128 bits

Recover the Key

ECPubKey from server
Device key
Online key

SHA256(Device key * ECPubKey || Online key)

Take first 128 bits

This is in effect a method of allowing the user to extend the account creation process over a period of time suited to them.

We have implemented a new Security Checklist to take them through the process of fully securing the account which makes it clear the steps they have to follow before their account setup is considered complete.

We also added reminders to instruct the user to complete the key backup process on address creation and, if the user has a balance of over ~$5, every time they enter their PIN number.


