### PR TITLE
Backend: Update Kramdown Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
   gem 'jekyll', '~>1.3.0'
   gem 'json'
   gem 'less'
-  gem 'kramdown'
+  gem 'kramdown', '~>1.6.0'
   gem 'RedCloth'
   gem 'therubyracer' # required by less
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       redcarpet (~> 2.3.0)
       safe_yaml (~> 0.9.7)
     json (1.8.1)
-    kramdown (1.3.3)
+    kramdown (1.6.0)
     less (2.4.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.3)
@@ -82,6 +82,6 @@ DEPENDENCIES
   html-proofer
   jekyll (~> 1.3.0)
   json
-  kramdown
+  kramdown (~> 1.6.0)
   less
   therubyracer


### PR DESCRIPTION
Updates to a newer version of Kramdown, the library used to convert Markdown to HTML.  A diff of the generated website using the previous version to the new version is available [here](http://dtrt.org/diff.html).  There are only two changes that I see:

1. Automatically-generated table of contents for the various dev docs now have an id attribute assigned to each list item.  Every id starts with `markdown-toc-` so I doubt there are any conflicts with previous ids and I don't see any issues.

2. In plain-text paragraphs and list items converted to HTML by Kramdown, trailing whitespace is now removed. I confirmed this does not apply to anything inside pre tags. I also confirmed that it only applies to trailing whitespace.

Not visible is that the old version of Kramdown has problems with HTML `<button>`, which I ran into while working on a separate branch.  This update to the newer version fixes that.

Note: when merged, this PR will be the first test of the new automatic library upgrade feature on the build server.  I'll be standing by to fix any problems.  @saivann and anyone else who has previously built the website locally will need to run `bundle install` from their local repository directory to install the newer version of Kramdown.