### PR TITLE
Support blank spaces in file names when generating sha256sums.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build:
 	$S grep -r -L 'Note: this file is built non-deterministically' _site/ \
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
-	  | xargs sha256sum > _site/sha256sums.txt
+	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
 
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings


### PR DESCRIPTION
This bug was preventing translation live previews to be generated due to blank lines in the urls of some recent translations.

For instance, current unreviewed Spanish translations generate a "_site/es/documento de bitcoin.html" page. With the current Makefile, xargs would search for (and fail to find) "_site/es/documento", "de", and "bitcoin.html".

Such troublesome urls are prevented on the live website using the check-for-non-ascii-urls rules in the Makefile. However, live previews are meant to ignore such mistakes (using only "make build") so all working pages can be built and previewed without interruption.