### PR TITLE
New Plugin: Githubify Bitcoin Core Release Notes

### DIFF
--- a/_plugins/githubify.rb
+++ b/_plugins/githubify.rb
@@ -1,0 +1,73 @@
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+## githubify.rb automatically adds links to pull requests, issues, and
+## commits using pattern matches
+
+## Example (URL is the repository to link to):
+## {% githubify https://github.com/bitcoin/bitcoin %}
+## ...content...
+## {% endgithubify %}
+
+module Jekyll
+
+require 'yaml'
+
+  class GitHubifyBlock < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+      @repository_url = text.strip()
+    end
+
+    def render(context)
+      output = super
+
+      ## Convert #1234 into URL for the pull request
+      ## If #1234 links to an issue, GitHub automatically redirects
+      #
+      ## Require at least two digits to reduce false positive matches
+      output.gsub!(/#([0-9][0-9][0-9]*)/){ |s|
+        '<a href="' + @repository_url + '/pull/' + $1 + '">' + s + '</a>'
+      }
+
+      ## Convert `123abcd` into URL for the commit
+      #
+      ## Only operate on 7 to 10 chars to reduce false positive matches
+      output.gsub!(/`([0-9abcdef]{7,10})`/){ |s|
+        '<a href="' + @repository_url + '/commit/' + $1 + '">' + s + '</a>'
+      }
+
+      output
+    end
+  end
+end
+
+
+## Code to run if plugin is disabled
+module Jekyll
+
+require 'yaml'
+
+  class GitHubifyBlockDisabled < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+    end
+
+    def render(context)
+      output = super
+
+      output
+    end
+  end
+end
+
+#Do nothing if plugin is disabled
+plugin_name = "githubify"
+if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index(plugin_name).nil?
+  print plugin_name + ' disabled' + "\n"
+  Liquid::Template.register_tag(plugin_name, Jekyll::GitHubifyBlockDisabled)
+else
+  Liquid::Template.register_tag(plugin_name, Jekyll::GitHubifyBlock)
+end

--- a/_releases/0.10.0.md
+++ b/_releases/0.10.0.md
@@ -22,6 +22,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:170c61fe09dafecfbb97cb4dccd32173383f4e
 ## 2. Place URLs inside angle brackets, like <http://bitcoin.org/bin>
 
 ---
+{% githubify https://github.com/bitcoin/bitcoin %}
 Bitcoin Core version 0.10.0 is now available from:
 
   <https://bitcoin.org/bin/0.10.0/>
@@ -798,3 +799,4 @@ Thanks to everyone who contributed to this release:
 - Zak Wilcox
 
 As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+{% endgithubify %}

--- a/_releases/0.10.1.md
+++ b/_releases/0.10.1.md
@@ -22,6 +22,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:b6f8da60aaf2007cd6db631637951ae673e310
 ## 2. Place URLs inside angle brackets, like <http://bitcoin.org/bin>
 
 ---
+{% githubify https://github.com/bitcoin/bitcoin %}
 Bitcoin Core version 0.10.1 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.10.1/>
@@ -161,3 +162,4 @@ Thanks to everyone who contributed to this release:
 - Wladimir J. van der Laan
 
 As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+{% endgithubify %}

--- a/_releases/0.10.2.md
+++ b/_releases/0.10.2.md
@@ -22,6 +22,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:746a616aa8de97856c207e7a899c7ee315e8c4
 ## 2. Place URLs inside angle brackets, like <http://bitcoin.org/bin>
 
 ---
+{% githubify https://github.com/bitcoin/bitcoin %}
 Bitcoin Core version 0.10.2 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.10.2/>
@@ -109,3 +110,4 @@ And all those who contributed additional code review and/or security research:
 
 As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 
+{% endgithubify %}


### PR DESCRIPTION
Starting with the 0.10.x series, @laanwj began adding commit ids to the release notes.  In the 0.11.0 notes, he also adds pull request numbers.

This PR adds a plugin that automatically converts those ids and PR#s into links.  Previews:

* http://dg1.dtrt.org/en/release/v0.10.0
* http://dg1.dtrt.org/en/release/v0.10.1
* http://dg1.dtrt.org/en/release/v0.10.2

HTML diff (I don't see any false positive matches or other unwanted changes): http://dg1.dtrt.org/diff.html

I already have the initial 0.11.0 release commit based on top of this, so a preview for that will be available as soon as I finish testing it and writing the PR notes.