### PR TITLE
Blog: Bitcoin.org Position On Hard Forks

### DIFF
--- a/_posts/2015-06-16-hard-fork-policy.md
+++ b/_posts/2015-06-16-hard-fork-policy.md
@@ -8,20 +8,17 @@ title: "Bitcoin.org Hard Fork Policy"
 permalink: /en/posts/hard-fork-policy.html
 date: 2015-06-16
 ---
-It appears that the recent block size debate will likely result in a
-contentious hard fork attempt.
-
 Contentious hard forks are bad for Bitcoin. At the very best, a
 contentious hard fork will leave people who chose the losing side of the
 fork feeling disenfranchised. At the very worst, it will make bitcoins
 permanently lose their value. In between are many possible outcomes, but
-none of them is good.
+none of them are good.
 
 The danger of a contentious hard fork is potentially so significant
 that Bitcoin.org has decided to adopt a new policy:
 
 > Bitcoin.org will not promote software or services that will leave the
-> previous consensus because of a contentious hard fork attempt.
+> previous consensus because of an intentional and contentious hard fork attempt.
 
 This policy applies to full node software, such as Bitcoin Core,
 software forks of Bitcoin Core, and alternative full node
@@ -37,5 +34,5 @@ fork and which continues doing whatever it would've done anyway.
 To be clear, we encourage wallet authors and service providers to offer
 their opinions on hard fork proposals, and we will not penalize anyone
 for contributing to a discussion. We will only stop promoting particular
-wallets and services if they plan to move their users onto the
+wallets and services if they plan to move their users onto a
 contentious hard fork by default.

--- a/_posts/2015-06-16-hard-fork-policy.md
+++ b/_posts/2015-06-16-hard-fork-policy.md
@@ -1,0 +1,39 @@
+---
+type: posts
+layout: post
+lang: en
+category: blog
+
+title: "Bitcoin.org Hard Fork Policy"
+permalink: /en/posts/hard-fork-policy.html
+date: 2015-06-16
+---
+It appears that the recent block size debate will likely result in a
+contentious hard fork attempt.
+
+Contentious hard forks are bad for Bitcoin. At the very best, a
+contentious hard fork will leave people who chose the losing side of the
+fork feeling disenfranchised. At the very worst, it will make bitcoins
+permanently lose their value. In between are many possible outcomes, but
+none of them is good.
+
+The danger of a contentious hard fork is potentially so significant
+that Bitcoin.org has decided to adopt a new policy:
+
+> Bitcoin.org will not promote software or services that will leave the
+> previous consensus because of a contentious hard fork attempt.
+
+This policy applies to full node software, such as Bitcoin Core,
+software forks of Bitcoin Core, and alternative full node
+implementations.
+
+It also applies to wallets and services that have the ability to detect
+the contentious hard fork, and which release code or make announcements
+indicating that they will cease operating on the side of the previous
+consensus.
+
+To be clear, we encourage wallet authors and service providers to offer
+their opinions on hard fork proposals, and we will not penalize anyone
+for contributing to a discussion. We will only stop promoting particular
+wallets and services if they plan to move their users onto the
+contentious hard fork by default.

--- a/_posts/2015-06-16-hard-fork-policy.md
+++ b/_posts/2015-06-16-hard-fork-policy.md
@@ -31,6 +31,8 @@ It also applies to wallets and services that have the ability to detect
 the contentious hard fork, and which release code or make announcements
 indicating that they will cease operating on the side of the previous
 consensus.
+It does not apply to software that cannot detect the contentious hard
+fork and which continues doing whatever it would've done anyway.
 
 To be clear, we encourage wallet authors and service providers to offer
 their opinions on hard fork proposals, and we will not penalize anyone


### PR DESCRIPTION
This blog post introduces a new policy for Bitcoin.org regarding contentious hard forks:

> Bitcoin.org will not promote software or services that will leave the previous consensus because of a contentious hard fork attempt.

Full explanation can be found in the blog post itself using the GitHub diff on the screenshot preview below.

This statement, or earlier revisions of it, has been reviewed by the following persons:

* @theymos (Bitcoin.org domain co-owner)
* Cobra (Bitcoin.org domain co-owner)
* @saivann (Bitcoin.org site co-maintainer)
* @harding (Bitcoin.org site co-maintainer)

We also feel that this statement reflects the published sentiments of many of Bitcoin.org's active reviewers, and we invite them to individually ACK this PR if that is the case.  If a sufficient number ACK this PR today, we will merge today.  If not, we will merge tomorrow (Tuesday) unless unexpected criticism is received.

![hard-fork-blog](https://cloud.githubusercontent.com/assets/61096/8162837/d2c9b502-134d-11e5-9a8b-27c65c0e0356.png)
