### PR TITLE
Revise Hard Fork Policy

### DIFF
--- a/_posts/2015-06-16-hard-fork-policy.md
+++ b/_posts/2015-06-16-hard-fork-policy.md
@@ -8,31 +8,15 @@ title: "Bitcoin.org Hard Fork Policy"
 permalink: /en/posts/hard-fork-policy.html
 date: 2015-06-16
 ---
-Contentious hard forks are bad for Bitcoin. At the very best, a
-contentious hard fork will leave people who chose the losing side of the
-fork feeling disenfranchised. At the very worst, it will make bitcoins
-permanently lose their value. In between are many possible outcomes, but
-none of them are good.
-
-The danger of a contentious hard fork is potentially so significant
-that Bitcoin.org has decided to adopt a new policy:
-
-> Bitcoin.org will not promote software or services that will leave the
-> previous consensus because of an intentional and contentious hard fork attempt.
-
 This policy applies to full node software, such as Bitcoin Core,
-software forks of Bitcoin Core, and alternative full node
-implementations.
+software forks of Bitcoin Core, and alternative full node implementations.
 
 It also applies to wallets and services that have the ability to detect
-the contentious hard fork, and which release code or make announcements
-indicating that they will cease operating on the side of the previous
-consensus.
-It does not apply to software that cannot detect the contentious hard
-fork and which continues doing whatever it would've done anyway.
+hard forks, and which release code or make announcements indicating that
+they will cease operating on the side of the majority consensus.
 
-To be clear, we encourage wallet authors and service providers to offer
-their opinions on hard fork proposals, and we will not penalize anyone
-for contributing to a discussion. We will only stop promoting particular
-wallets and services if they plan to move their users onto a
-contentious hard fork by default.
+>>Wallet authors and service providers who would like to discuss their opinions
+>>or contributions relating to hard forks should open an issue or submit
+>>a pull request specific to their requested change.
+
+Core developers and contributors will review these on a case-by-case basis.


### PR DESCRIPTION
* Remove references to "Contentious" - arguably everything on Earth could be considered contentious.
* Remove speculative conjecture about what happens with Hard Forks. There's never been one to the degree that's being alluded to in the post - this is fear-mongering at that the very least and is potentially going to destroy confidence in new users who are considering entering the space in a multitude of contexts.
* Update policy to direct people to creating Issues or Pull Requests. It goes without saying that Bitcoin.org isn't going to support something that is bad for Bitcoin. We don't need a notice about it.

It's pretty clear that no matter what, a group of people want to have some sort of policy. Obviously, me and some others would prefer we not have one at all, but that doesn't mean we can't try to work like a team and a community of developers and contributors to find a compromise.

Let's try again and find something in the middle of what I'm suggesting and what @harding posted.

We can't always do things that everyone's going to be happy about or agree with, but we could have done better to try and more comprehensively represent our community today. That's what Bitcoin.org is about. That's what Bitcoin is about.

Not like this.