### PR TITLE
Update choose-your-wallet.html

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -186,9 +186,9 @@ wallets:
           validation: "checkpassvalidationspvp2p"
           transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
-          privacy: "checkfailprivacyweak"
+          privacy: "checkpassprivacybasic"
         privacycheck:
-          privacyaddressreuse: "checkfailprivacyaddressrotation"
+          privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurespv"
           privacynetwork: "checkfailprivacynetworknosupporttor"
 - airbitzwallet:


### PR DESCRIPTION
A few weeks ago, I updated the BlackBerry version of the app to the same codebase as the Android version. So it now supports HD wallets and tries its best to not reuse addresses.