### PR TITLE
Add Non-Profit; Bitcoin Embassy Amsterdam

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -157,6 +157,7 @@ id: community
     <h3 id="netherlands"><img src="/img/flags/NL.png" alt="Dutch flag">Netherlands</h3>
     <p>
       <a href="http://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a>
+      <a href="http://www.bitcoinembassy.nl/">Bitcoin Embassy Amsterdam</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This adds Bitcoin Embassy Amsterdam to the [Community page](https://bitcoin.org/en/community#nonprofit-organizations), as discussed with @martijnw in Issue #893.